### PR TITLE
firmware: add authenticated OTA web UI, stats page, and JSON API

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,224 @@
+# HTTP API
+
+This firmware exposes a small HTTP API alongside the web UI.
+
+All API routes:
+- are LAN-only
+- use the same HTTP Basic Auth as the web UI
+- use username `admin`
+- return JSON on success
+
+Base URL examples:
+- `http://192.168.1.42`
+- `http://heltec-ab12cd.local`
+
+Example auth:
+
+```bash
+curl -u admin:YOUR_PASSWORD http://192.168.1.42/api/stats
+```
+
+## Endpoints
+
+### `GET /api/temp`
+
+Returns only the die temperature plus basic identity.
+
+Example:
+
+```json
+{
+  "die_temperature_c": 24,
+  "firmware": "v0.7.0-heltec_v3",
+  "hostname": "heltec-ab12cd"
+}
+```
+
+### `GET /api/system`
+
+Returns basic device identity and live host connection info.
+
+Example:
+
+```json
+{
+  "board": "Heltec WiFi LoRa 32 V3",
+  "firmware": "v0.7.0-heltec_v3",
+  "hostname": "heltec-ab12cd",
+  "mdns": "heltec-ab12cd.local",
+  "interface": "Wi-Fi",
+  "current_ip": "192.168.1.42",
+  "connected_client_ip": "192.168.1.10",
+  "uptime_sec": 42,
+  "uptime": "00:00:42",
+  "die_temperature_c": 24
+}
+```
+
+### `GET /api/radio`
+
+Returns the current live radio settings.
+
+Example:
+
+```json
+{
+  "state": "RX/Idle",
+  "standby": false,
+  "auto_cad_enabled": false,
+  "frequency_hz": 910525000,
+  "frequency_mhz": 910.525,
+  "bandwidth_hz": 62500,
+  "bandwidth_khz": 62.5,
+  "spreading_factor": 7,
+  "coding_rate": 5,
+  "tx_power_dbm": 22,
+  "syncword": "0x3444",
+  "syncword_value": 13380,
+  "preamble_len": 17
+}
+```
+
+### `GET /api/network`
+
+Returns live network status plus the saved network configuration.
+
+Example:
+
+```json
+{
+  "mode": "static",
+  "use_static_ip": true,
+  "interface": "Wi-Fi",
+  "live": true,
+  "current_ip": "192.168.1.42",
+  "subnet": "255.255.255.0",
+  "gateway": "192.168.1.1",
+  "dns1": "1.1.1.1",
+  "dns2": "8.8.8.8",
+  "tcp_port": 5055,
+  "pymc_token_set": true,
+  "saved": {
+    "static_ip": "192.168.1.42",
+    "subnet": "255.255.255.0",
+    "gateway": "192.168.1.1",
+    "dns1": "1.1.1.1",
+    "dns2": "8.8.8.8"
+  }
+}
+```
+
+### `GET /api/stats`
+
+Returns the combined system, radio, counters, and network state in one response.
+
+Top-level keys:
+- `system`
+- `radio`
+- `counters`
+- `network`
+
+### `GET /api/config`
+
+Returns the saved editable configuration.
+
+Example:
+
+```json
+{
+  "hostname": "heltec-ab12cd",
+  "effective_hostname": "heltec-ab12cd",
+  "tcp_token": "your-token",
+  "tcp_port": 5055,
+  "use_static_ip": true,
+  "static_ip": "192.168.1.42",
+  "subnet": "255.255.255.0",
+  "gateway": "192.168.1.1",
+  "dns1": "1.1.1.1",
+  "dns2": "8.8.8.8"
+}
+```
+
+### `POST /api/config`
+
+Updates saved config and reboots the modem.
+
+Accepted top-level fields:
+- `hostname`
+- `tcp_token`
+- `tcp_port`
+- `use_static_ip`
+- `network`
+
+`network` fields:
+- `use_static_ip`
+- `static_ip`
+- `subnet`
+- `gateway`
+- `dns1`
+- `dns2`
+
+Notes:
+- fields you omit are left unchanged
+- set `hostname` to `""` to reset to the default MAC-derived hostname
+- set `tcp_token` to `""` to clear the pyMC token
+- if `use_static_ip` is `true`, `static_ip`, `subnet`, and `gateway` must be valid
+- a successful request always reboots the modem
+
+Example:
+
+```bash
+curl -u admin:YOUR_PASSWORD \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "hostname": "heltec-ab12cd",
+    "tcp_token": "meshpass",
+    "network": {
+      "use_static_ip": true,
+      "static_ip": "192.168.1.42",
+      "subnet": "255.255.255.0",
+      "gateway": "192.168.1.1",
+      "dns1": "1.1.1.1",
+      "dns2": "8.8.8.8"
+    }
+  }' \
+  http://192.168.1.42/api/config
+```
+
+Success response:
+
+```json
+{
+  "status": "saved",
+  "rebooting": true,
+  "config": {
+    "...": "updated values"
+  }
+}
+```
+
+Error response:
+
+```json
+{
+  "error": "message here"
+}
+```
+
+### `POST /api/reboot`
+
+Reboots the modem immediately.
+
+Example:
+
+```bash
+curl -u admin:YOUR_PASSWORD -X POST http://192.168.1.42/api/reboot
+```
+
+Response:
+
+```json
+{
+  "status": "rebooting"
+}
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,12 +89,14 @@ Once the board is on the LAN (Wi-Fi STA or Ethernet) and visible via mDNS:
 cd firmware
 pio run -e <env> -t upload --upload-port <env-stem>-<mac3>.local
 # or HTTP directly:
-curl -F firmware=@.pio/build/<env>/firmware.bin \
+curl -u admin:password -F firmware=@.pio/build/<env>/firmware.bin \
      http://<env-stem>-<mac3>.local/update
 ```
 
 Hostname stems are listed in §1 (e.g. `heltec`, `ikoka`,
 `lilygo-t3s3`, `rak3112`, `p4nano`). The board reboots after upload.
+The HTTP OTA page uses Basic Auth with username `admin` and default
+password `password`; change it from the OTA page after first network boot.
 Rollback is **not** automatic on a broken image — keep the USB cable
 as a recovery fallback.
 

--- a/firmware/include/ethernet_manager.h
+++ b/firmware/include/ethernet_manager.h
@@ -17,7 +17,13 @@ namespace EthernetManager {
 // DHCP hostname, calls ETH.begin() with the parameters from
 // BOARD.ethernet, then waits up to ~5 s for the link to come up and
 // DHCP to lease an address. Watchdog-friendly.
-void begin(const char* hostname = nullptr);
+void begin(const char* hostname = nullptr,
+           bool useStaticIP = false,
+           const IPAddress& staticIP = IPAddress((uint32_t)0),
+           const IPAddress& gateway = IPAddress((uint32_t)0),
+           const IPAddress& subnet = IPAddress((uint32_t)0),
+           const IPAddress& dns1 = IPAddress((uint32_t)0),
+           const IPAddress& dns2 = IPAddress((uint32_t)0));
 
 // Tear down the EMAC + netif. After this call, isLinkUp() / hasIP()
 // return false and the RMII GPIOs are released so another driver

--- a/firmware/include/ethernet_manager.h
+++ b/firmware/include/ethernet_manager.h
@@ -13,10 +13,11 @@
 
 namespace EthernetManager {
 
-// Bring the EMAC + PHY up. Drives PHY reset, calls ETH.begin() with
-// the parameters from BOARD.ethernet, then waits up to ~5 s for the
-// link to come up and DHCP to lease an address. Watchdog-friendly.
-void begin();
+// Bring the EMAC + PHY up. Drives PHY reset, applies the requested
+// DHCP hostname, calls ETH.begin() with the parameters from
+// BOARD.ethernet, then waits up to ~5 s for the link to come up and
+// DHCP to lease an address. Watchdog-friendly.
+void begin(const char* hostname = nullptr);
 
 // Tear down the EMAC + netif. After this call, isLinkUp() / hasIP()
 // return false and the RMII GPIOs are released so another driver

--- a/firmware/include/ota_manager.h
+++ b/firmware/include/ota_manager.h
@@ -1,9 +1,9 @@
 // =============================================================
 // ota_manager.h — OTA firmware update over Wi-Fi (STA mode)
 //
-// Two routes, both always-on whenever STA is connected:
+// Two routes, both always-on whenever a network interface is connected:
 //   - ArduinoOTA  : espota.py / pio run -t upload --upload-port <host>.local
-//   - HTTP POST   : curl -F firmware=@firmware.bin http://<host>.local/update
+//   - HTTP POST   : curl -u admin:<password> -F firmware=@firmware.bin http://<host>.local/update
 //
 // Dual-bank rollback: new firmware only "stays" if it passes a sanity
 // check (SX1262 init OK + at least one valid USB/TCP frame received
@@ -18,9 +18,10 @@
 namespace OTAManager {
 
 // Start ArduinoOTA + HTTP /update endpoint on port 80.
-// `token` is reused from WifiManager config — if non-empty, HTTP /update
-// requires Basic auth with user="heltec", pass=token; ArduinoOTA uses the
-// same value as its upload password. Must be called after WiFi STA is up.
+// HTTP requires Basic auth with user="admin" and an NVS-backed password
+// that defaults to "password"; the web page exposes a password-change form.
+// ArduinoOTA uses the TCP token when one is configured, otherwise the same
+// HTTP password. Must be called after Wi-Fi STA or Ethernet is up.
 void begin(const String& hostname, const String& token);
 
 // Service pending OTA transactions + feed the rollback sanity watchdog.

--- a/firmware/include/protocol.h
+++ b/firmware/include/protocol.h
@@ -134,6 +134,7 @@
 //  pass_len(1B) | pass(M)
 //  port(2B LE)
 //  token_len(1B) | token(K)
+//  [host_len(1B) | hostname(H)]   // optional; blank/omitted = MAC-derived default
 //
 //  Modem ACKs with WIFI_STATUS (new pending config), then reboots.
 //

--- a/firmware/include/runtime_stats.h
+++ b/firmware/include/runtime_stats.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Arduino.h>
+#include "protocol.h"
+
+namespace RuntimeStats {
+
+struct Snapshot {
+    StatusResp status;
+    RadioConfig radio;
+    String firmwareVersion;
+    bool radioStandby;
+    bool autoCadEnabled;
+};
+
+Snapshot capture();
+
+}

--- a/firmware/include/wifi_manager.h
+++ b/firmware/include/wifi_manager.h
@@ -19,6 +19,7 @@ enum class Mode : uint8_t {
 struct Config {
     String    ssid;
     String    password;
+    String    hostname;   // empty = derive "<board>-XXXXXX" from MAC
     bool      useStaticIP;
     IPAddress staticIP;
     IPAddress gateway;
@@ -46,6 +47,7 @@ void loop();
 Mode        getMode();
 const char* getSSID();        // current STA SSID, or AP SSID in AP_CONFIG
 const char* getIPString();    // dotted quad, "---" when offline
+const char* getHostname();    // configured hostname, or MAC-derived fallback
 bool        isSTAConnected();
 bool        isAPActive();
 

--- a/firmware/include/wifi_manager.h
+++ b/firmware/include/wifi_manager.h
@@ -24,7 +24,8 @@ struct Config {
     IPAddress staticIP;
     IPAddress gateway;
     IPAddress subnet;
-    IPAddress dns;
+    IPAddress dns1;
+    IPAddress dns2;
     String    tcpToken;  // empty = no auth required
     uint16_t  tcpPort;   // default 5055
 };

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -14,6 +14,7 @@ lib_deps =
     jgromes/RadioLib@^7.1.0
     adafruit/Adafruit SSD1306@^2.5.7
     adafruit/Adafruit GFX Library@^1.11.5
+    bblanchon/ArduinoJson@^7.0.4
 
 build_flags =
     -DARDUINO_USB_MODE=1
@@ -193,4 +194,3 @@ build_src_filter =
     -<ota_manager.cpp>
     -<config_portal.cpp>
     -<oled_display.cpp>
-

--- a/firmware/src/config_portal.cpp
+++ b/firmware/src/config_portal.cpp
@@ -120,6 +120,9 @@ static void handleRoot() {
     html += "<input type='text' name='dns' value='" + cfg.dns.toString() + "' placeholder='1.1.1.1'>";
 
     html += F("<hr>");
+    html += F("<label>Hostname <span class='hint'>(optional; blank = default mDNS name)</span></label>");
+    html += "<input type='text' name='hostname' autocomplete='off' maxlength='32' value='" +
+            htmlEscape(cfg.hostname) + "' placeholder='ethermesh-1w'>";
     html += F("<label>TCP port</label>");
     html += "<input type='number' name='port' min='1' max='65535' value='" + String(cfg.tcpPort) + "'>";
     html += F("<label>TCP auth token <span class='hint'>(optional; empty = no auth)</span></label>");
@@ -153,14 +156,17 @@ static void handleSave() {
     newCfg.subnet      = parseIP(server->arg("sn"));
     newCfg.dns         = parseIP(server->arg("dns"));
     newCfg.tcpToken    = server->arg("token");
+    newCfg.hostname    = server->arg("hostname");
+    newCfg.hostname.trim();
 
     int port = server->arg("port").toInt();
     if (port < 1 || port > 65535) port = 5055;
     newCfg.tcpPort = (uint16_t)port;
 
     Serial.printf("[Portal] POST /save: ssid_sel='%s' ssid_manual='%s' -> ssid='%s' "
-                  "password_len=%u static=%d port=%u token_len=%u\n",
+                  "host='%s' password_len=%u static=%d port=%u token_len=%u\n",
                   ssidSel.c_str(), ssidMan.c_str(), newCfg.ssid.c_str(),
+                  newCfg.hostname.c_str(),
                   (unsigned)newCfg.password.length(),
                   (int)newCfg.useStaticIP,
                   (unsigned)newCfg.tcpPort,

--- a/firmware/src/config_portal.cpp
+++ b/firmware/src/config_portal.cpp
@@ -116,8 +116,10 @@ static void handleRoot() {
     html += "<input type='text' name='gw' value='" + cfg.gateway.toString() + "' placeholder='192.168.1.1'>";
     html += F("<label>Subnet mask</label>");
     html += "<input type='text' name='sn' value='" + cfg.subnet.toString() + "' placeholder='255.255.255.0'>";
-    html += F("<label>DNS</label>");
-    html += "<input type='text' name='dns' value='" + cfg.dns.toString() + "' placeholder='1.1.1.1'>";
+    html += F("<label>DNS 1</label>");
+    html += "<input type='text' name='dns1' value='" + cfg.dns1.toString() + "' placeholder='1.1.1.1'>";
+    html += F("<label>DNS 2</label>");
+    html += "<input type='text' name='dns2' value='" + cfg.dns2.toString() + "' placeholder='8.8.8.8'>";
 
     html += F("<hr>");
     html += F("<label>Hostname <span class='hint'>(optional; blank = default mDNS name)</span></label>");
@@ -154,7 +156,8 @@ static void handleSave() {
     newCfg.staticIP    = parseIP(server->arg("ip"));
     newCfg.gateway     = parseIP(server->arg("gw"));
     newCfg.subnet      = parseIP(server->arg("sn"));
-    newCfg.dns         = parseIP(server->arg("dns"));
+    newCfg.dns1        = parseIP(server->arg("dns1"));
+    newCfg.dns2        = parseIP(server->arg("dns2"));
     newCfg.tcpToken    = server->arg("token");
     newCfg.hostname    = server->arg("hostname");
     newCfg.hostname.trim();

--- a/firmware/src/ethernet_manager.cpp
+++ b/firmware/src/ethernet_manager.cpp
@@ -15,6 +15,7 @@
 #if CONFIG_ETH_USE_ESP32_EMAC
 
 #include <ETH.h>
+#include <Network.h>
 #include <esp_task_wdt.h>
 
 namespace EthernetManager {
@@ -22,6 +23,20 @@ namespace EthernetManager {
 static bool   _started   = false;
 static char   _ip_str[20]  = "---";
 static char   _mac_str[18] = "";
+static String _pending_hostname;
+static network_event_handle_t _eth_event_handle = 0;
+
+static void onEthernetEvent(arduino_event_id_t event, arduino_event_info_t) {
+    if (event != ARDUINO_EVENT_ETH_START) return;
+    if (_pending_hostname.length() == 0) return;
+    if (ETH.setHostname(_pending_hostname.c_str())) {
+        Serial.printf("[ETH] hostname='%s' applied at ETH_START\n",
+                      _pending_hostname.c_str());
+    } else {
+        Serial.printf("[ETH] failed to apply hostname '%s' at ETH_START\n",
+                      _pending_hostname.c_str());
+    }
+}
 
 static eth_phy_type_t mapPhyType(BoardConfig::EthernetPhy phy) {
     switch (phy) {
@@ -74,38 +89,15 @@ void begin(const char* hostname,
 
     resetPhy(e.pin_phy_reset);
 
-    if (hostname && hostname[0] != '\0') {
-        if (ETH.setHostname(hostname)) {
-            Serial.printf("[ETH] hostname='%s'\n", hostname);
-        } else {
-            Serial.printf("[ETH] failed to set hostname '%s'\n", hostname);
-        }
-    }
-
     eth_phy_type_t phy = mapPhyType(e.phy_type);
     if (phy == ETH_PHY_MAX) {
         Serial.println("[ETH] unsupported phy_type — aborting");
         return;
     }
 
-    // Apply static IP BEFORE begin() — same idiom as WiFi.config().
-    // Runtime config wins; otherwise the board-level static config is used.
-    if (useStaticIP) {
-        ETH.config(staticIP, gateway, subnet, dns1, dns2);
-        Serial.printf("[ETH] static cfg %u.%u.%u.%u/%u.%u.%u.%u gw=%u.%u.%u.%u\n",
-                      staticIP[0], staticIP[1], staticIP[2], staticIP[3],
-                      subnet[0], subnet[1], subnet[2], subnet[3],
-                      gateway[0], gateway[1], gateway[2], gateway[3]);
-    } else if (e.use_static_ip) {
-        IPAddress ip  (e.static_ip[0], e.static_ip[1], e.static_ip[2], e.static_ip[3]);
-        IPAddress gw  (e.gateway[0],   e.gateway[1],   e.gateway[2],   e.gateway[3]);
-        IPAddress sn  (e.subnet[0],    e.subnet[1],    e.subnet[2],    e.subnet[3]);
-        IPAddress bd1 (e.dns[0],       e.dns[1],       e.dns[2],       e.dns[3]);
-        ETH.config(ip, gw, sn, bd1);
-        Serial.printf("[ETH] board static cfg %u.%u.%u.%u/%u.%u.%u.%u gw=%u.%u.%u.%u\n",
-                      ip[0], ip[1], ip[2], ip[3],
-                      sn[0], sn[1], sn[2], sn[3],
-                      gw[0], gw[1], gw[2], gw[3]);
+    _pending_hostname = (hostname && hostname[0] != '\0') ? String(hostname) : String();
+    if (_eth_event_handle == 0) {
+        _eth_event_handle = Network.onEvent(onEthernetEvent, ARDUINO_EVENT_ETH_START);
     }
 
     // power pin (-1 = none); clock mode mapped per-target above.
@@ -120,6 +112,38 @@ void begin(const char* hostname,
         return;
     }
     _started = true;
+
+    if (_pending_hostname.length() > 0) {
+        const char* applied = ETH.getHostname();
+        Serial.printf("[ETH] netif hostname now '%s'\n",
+                      (applied && applied[0] != '\0') ? applied : "(empty)");
+    }
+
+    // Apply hostname/static settings only after ETH.begin(), because
+    // the Arduino NetworkInterface requires a live esp_netif first.
+    if (useStaticIP) {
+        if (ETH.config(staticIP, gateway, subnet, dns1, dns2)) {
+            Serial.printf("[ETH] static cfg %u.%u.%u.%u/%u.%u.%u.%u gw=%u.%u.%u.%u\n",
+                          staticIP[0], staticIP[1], staticIP[2], staticIP[3],
+                          subnet[0], subnet[1], subnet[2], subnet[3],
+                          gateway[0], gateway[1], gateway[2], gateway[3]);
+        } else {
+            Serial.println("[ETH] failed to apply runtime static config");
+        }
+    } else if (e.use_static_ip) {
+        IPAddress ip  (e.static_ip[0], e.static_ip[1], e.static_ip[2], e.static_ip[3]);
+        IPAddress gw  (e.gateway[0],   e.gateway[1],   e.gateway[2],   e.gateway[3]);
+        IPAddress sn  (e.subnet[0],    e.subnet[1],    e.subnet[2],    e.subnet[3]);
+        IPAddress bd1 (e.dns[0],       e.dns[1],       e.dns[2],       e.dns[3]);
+        if (ETH.config(ip, gw, sn, bd1)) {
+            Serial.printf("[ETH] board static cfg %u.%u.%u.%u/%u.%u.%u.%u gw=%u.%u.%u.%u\n",
+                          ip[0], ip[1], ip[2], ip[3],
+                          sn[0], sn[1], sn[2], sn[3],
+                          gw[0], gw[1], gw[2], gw[3]);
+        } else {
+            Serial.println("[ETH] failed to apply board static config");
+        }
+    }
 
     // Cache MAC for later getMACString() lookups; ETH.macAddress() is
     // valid as soon as begin() returns true.

--- a/firmware/src/ethernet_manager.cpp
+++ b/firmware/src/ethernet_manager.cpp
@@ -56,7 +56,13 @@ static void resetPhy(int8_t rst_pin) {
     delay(50);   // datasheet: IP101 needs ≥10 ms after RST deassert
 }
 
-void begin(const char* hostname) {
+void begin(const char* hostname,
+           bool useStaticIP,
+           const IPAddress& staticIP,
+           const IPAddress& gateway,
+           const IPAddress& subnet,
+           const IPAddress& dns1,
+           const IPAddress& dns2) {
     if (!BOARD.ethernet.enabled) return;
 
     const auto& e = BOARD.ethernet;
@@ -83,14 +89,20 @@ void begin(const char* hostname) {
     }
 
     // Apply static IP BEFORE begin() — same idiom as WiFi.config().
-    // When use_static_ip is false the call is skipped and DHCP is used.
-    if (e.use_static_ip) {
-        IPAddress ip   (e.static_ip[0], e.static_ip[1], e.static_ip[2], e.static_ip[3]);
-        IPAddress gw   (e.gateway[0],   e.gateway[1],   e.gateway[2],   e.gateway[3]);
-        IPAddress sn   (e.subnet[0],    e.subnet[1],    e.subnet[2],    e.subnet[3]);
-        IPAddress dns1 (e.dns[0],       e.dns[1],       e.dns[2],       e.dns[3]);
-        ETH.config(ip, gw, sn, dns1);
+    // Runtime config wins; otherwise the board-level static config is used.
+    if (useStaticIP) {
+        ETH.config(staticIP, gateway, subnet, dns1, dns2);
         Serial.printf("[ETH] static cfg %u.%u.%u.%u/%u.%u.%u.%u gw=%u.%u.%u.%u\n",
+                      staticIP[0], staticIP[1], staticIP[2], staticIP[3],
+                      subnet[0], subnet[1], subnet[2], subnet[3],
+                      gateway[0], gateway[1], gateway[2], gateway[3]);
+    } else if (e.use_static_ip) {
+        IPAddress ip  (e.static_ip[0], e.static_ip[1], e.static_ip[2], e.static_ip[3]);
+        IPAddress gw  (e.gateway[0],   e.gateway[1],   e.gateway[2],   e.gateway[3]);
+        IPAddress sn  (e.subnet[0],    e.subnet[1],    e.subnet[2],    e.subnet[3]);
+        IPAddress bd1 (e.dns[0],       e.dns[1],       e.dns[2],       e.dns[3]);
+        ETH.config(ip, gw, sn, bd1);
+        Serial.printf("[ETH] board static cfg %u.%u.%u.%u/%u.%u.%u.%u gw=%u.%u.%u.%u\n",
                       ip[0], ip[1], ip[2], ip[3],
                       sn[0], sn[1], sn[2], sn[3],
                       gw[0], gw[1], gw[2], gw[3]);
@@ -182,7 +194,8 @@ const char* getMACString() {
 #else  // !CONFIG_ETH_USE_ESP32_EMAC — chip has no internal EMAC
 
 namespace EthernetManager {
-void        begin(const char*) {}
+void        begin(const char*, bool, const IPAddress&, const IPAddress&, const IPAddress&,
+                  const IPAddress&, const IPAddress&) {}
 void        end()          {}
 void        loop()         {}
 bool        isLinkUp()     { return false; }

--- a/firmware/src/ethernet_manager.cpp
+++ b/firmware/src/ethernet_manager.cpp
@@ -56,7 +56,7 @@ static void resetPhy(int8_t rst_pin) {
     delay(50);   // datasheet: IP101 needs ≥10 ms after RST deassert
 }
 
-void begin() {
+void begin(const char* hostname) {
     if (!BOARD.ethernet.enabled) return;
 
     const auto& e = BOARD.ethernet;
@@ -67,6 +67,14 @@ void begin() {
                   e.rmii_clock_input ? "EXT_IN" : "INT_OUT");
 
     resetPhy(e.pin_phy_reset);
+
+    if (hostname && hostname[0] != '\0') {
+        if (ETH.setHostname(hostname)) {
+            Serial.printf("[ETH] hostname='%s'\n", hostname);
+        } else {
+            Serial.printf("[ETH] failed to set hostname '%s'\n", hostname);
+        }
+    }
 
     eth_phy_type_t phy = mapPhyType(e.phy_type);
     if (phy == ETH_PHY_MAX) {
@@ -174,7 +182,7 @@ const char* getMACString() {
 #else  // !CONFIG_ETH_USE_ESP32_EMAC — chip has no internal EMAC
 
 namespace EthernetManager {
-void        begin()        {}
+void        begin(const char*) {}
 void        end()          {}
 void        loop()         {}
 bool        isLinkUp()     { return false; }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -236,24 +236,6 @@ void onDio1Rise() {
     dio1Flag = true;
 }
 
-// ─── Hostname derivation (deterministic from MAC) ───────────
-// "<prefix>-XXXXXX" from last 3 MAC bytes. No OLED needed to find
-// device — host resolves it via mDNS: e.g. `heltec-ab12cd.local`
-// or `ikoka-ab12cd.local` depending on the board.
-static String buildHostname() {
-    // Read directly from eFuse so this works even on boards where the
-    // Wi-Fi stack hasn't been initialised (ESP32-P4 with the C6 SDIO
-    // bridge unprovisioned). esp_efuse_mac_get_default() returns the
-    // base MAC; WiFi STA MAC == base MAC, so the value is the same as
-    // the previous WiFi.macAddress() call.
-    uint8_t mac[6] = {0};
-    compatGetMac(mac);
-    char buf[40];
-    snprintf(buf, sizeof(buf), "%s-%02x%02x%02x",
-             BOARD.mdns_prefix, mac[3], mac[4], mac[5]);
-    return String(buf);
-}
-
 // ─── E22 RF switch boot sequence ────────────────────────────
 // Some carrier boards (Ebyte E22-P series, see datasheet §4.2) need
 // their EN pin held LOW for several seconds at power-up so the LDOs
@@ -450,16 +432,18 @@ static uint16_t buildWifiStatusPayload(uint8_t* out) {
     out[i++] = ssid_len;
     if (ssid_len) { memcpy(out + i, ssid, ssid_len); i += ssid_len; }
 
-    uint8_t host_len = (uint8_t)deviceHostname.length();
+    const char* host = WifiManager::getHostname();
+    uint8_t host_len = host ? (uint8_t)strnlen(host, 32) : 0;
     if (host_len > 32) host_len = 32;
     out[i++] = host_len;
-    if (host_len) { memcpy(out + i, deviceHostname.c_str(), host_len); i += host_len; }
+    if (host_len) { memcpy(out + i, host, host_len); i += host_len; }
 
     return i;
 }
 
 // ─── SET_WIFI payload parser ────────────────────────────────
-// Layout: ssid_len(1) ssid(N) pass_len(1) pass(M) port(2,LE) tok_len(1) tok(K)
+// Layout: ssid_len(1) ssid(N) pass_len(1) pass(M) port(2,LE)
+//         tok_len(1) tok(K) [host_len(1) host(H)]
 // Only meaningful when the firmware actually has a Wi-Fi stack;
 // the nRF52 build (Heltec T114) doesn't, so the parser is gone
 // from the binary entirely.
@@ -490,6 +474,17 @@ static bool parseSetWifi(const uint8_t* p, uint16_t len, WifiManager::Config& ou
     uint8_t tlen = p[i++];
     if (tlen > 64 || i + tlen > len) return false;
     out.tcpToken = tlen ? String((const char*)(p + i), tlen) : String();
+    i += tlen;
+
+    if (i < len) {
+        if (i + 1 > len) return false;
+        uint8_t hlen = p[i++];
+        if (hlen > 32 || i + hlen > len) return false;
+        out.hostname = hlen ? String((const char*)(p + i), hlen) : String();
+        i += hlen;
+    }
+
+    if (i != len) return false;
 
     out.useStaticIP = false;   // USB provisioning = DHCP only
     return true;
@@ -1260,14 +1255,13 @@ void setup() {
 
     if (!useEthernet && BOARD.has_wifi) {
         WifiManager::begin();
-        WiFi.setHostname(buildHostname().c_str());
     } else {
         // Either Ethernet won, or Wi-Fi is compile-time disabled. We
         // still need the saved tcpPort/tcpToken loaded from NVS for
         // the TCP server config below.
         WifiManager::loadConfigOnly();
     }
-    deviceHostname = buildHostname();
+    deviceHostname = WifiManager::getHostname();
 
     bool netUp = WifiManager::isSTAConnected() || EthernetManager::hasIP();
     if (netUp) {

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1242,9 +1242,16 @@ void setup() {
     // GPIOs are released) and fall back to Wi-Fi. Boards without
     // Ethernet (`ethernet.enabled = false`) skip straight to Wi-Fi.
     WifiManager::loadConfigOnly();
+    const auto& netCfg = WifiManager::getConfig();
     bool useEthernet = false;
     if (BOARD.ethernet.enabled) {
-        EthernetManager::begin(WifiManager::getHostname());   // waits up to 5 s for link + DHCP
+        EthernetManager::begin(WifiManager::getHostname(),
+                               netCfg.useStaticIP,
+                               netCfg.staticIP,
+                               netCfg.gateway,
+                               netCfg.subnet,
+                               netCfg.dns1,
+                               netCfg.dns2);   // waits up to 5 s for link + DHCP
         if (EthernetManager::isLinkUp()) {
             useEthernet = true;
             Serial.println("[NET] Ethernet link up — Wi-Fi will be skipped");

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1241,9 +1241,10 @@ void setup() {
     // and skip Wi-Fi; if no link we tear EMAC back down (so the RMII
     // GPIOs are released) and fall back to Wi-Fi. Boards without
     // Ethernet (`ethernet.enabled = false`) skip straight to Wi-Fi.
+    WifiManager::loadConfigOnly();
     bool useEthernet = false;
     if (BOARD.ethernet.enabled) {
-        EthernetManager::begin();   // waits up to 5 s for link + DHCP
+        EthernetManager::begin(WifiManager::getHostname());   // waits up to 5 s for link + DHCP
         if (EthernetManager::isLinkUp()) {
             useEthernet = true;
             Serial.println("[NET] Ethernet link up — Wi-Fi will be skipped");
@@ -1256,10 +1257,8 @@ void setup() {
     if (!useEthernet && BOARD.has_wifi) {
         WifiManager::begin();
     } else {
-        // Either Ethernet won, or Wi-Fi is compile-time disabled. We
-        // still need the saved tcpPort/tcpToken loaded from NVS for
-        // the TCP server config below.
-        WifiManager::loadConfigOnly();
+        // Either Ethernet won, or Wi-Fi is compile-time disabled. The
+        // saved config was loaded above for hostname/TCP setup.
     }
     deviceHostname = WifiManager::getHostname();
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -38,6 +38,7 @@
 #  include "tcp_server.h"
 #  include "ota_manager.h"
 #  include "ethernet_manager.h"
+#  include "runtime_stats.h"
 #else
 // nRF52 (Heltec T114) build: the network / OLED / OTA managers are
 // excluded from the build via platformio.ini's build_src_filter.
@@ -227,6 +228,24 @@ static uint32_t maxLoopUs = 0;
 // Host-link health for the DIAGNOSTICS screen: millis() of the last USB
 // frame that parsed cleanly. 0 = no frame yet since boot.
 static uint32_t lastUsbCmdMs = 0;
+
+#ifdef ARDUINO_ARCH_ESP32
+namespace RuntimeStats {
+Snapshot capture() {
+    Snapshot snap = {};
+    snap.status = status;
+    snap.status.uptime_sec = millis() / 1000;
+    snap.status.radio_state = radioStandby ? 2 : (isTxActive ? 1 : 0);
+    snap.status.temp_c = (int8_t)temperatureRead();
+    snap.status.noise_floor_x10 = (int16_t)(noiseFloor * 10.0f);
+    snap.radio = currentConfig;
+    snap.firmwareVersion = fwVersion;
+    snap.radioStandby = radioStandby;
+    snap.autoCadEnabled = autoCadEnabled;
+    return snap;
+}
+}
+#endif
 
 // ─── ISR callback ────────────────────────────────────────────
 #if defined(ESP32)

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -7,6 +7,7 @@
 
 #include <ArduinoOTA.h>
 #include <ESPmDNS.h>
+#include <Preferences.h>
 #include <Update.h>
 #include <WebServer.h>
 #include <WiFi.h>
@@ -16,15 +17,51 @@ namespace OTAManager {
 
 static constexpr uint32_t SANITY_TIMEOUT_MS = 120000;  // mark firmware valid after 2 min of health
 static constexpr uint16_t HTTP_PORT         = 80;
+static constexpr const char* NVS_NAMESPACE  = "lora_modem";
+static constexpr const char* HTTP_PASS_KEY  = "http_pass";
+static constexpr const char* HTTP_AUTH_USER = "admin";
+static constexpr const char* DEFAULT_HTTP_PASSWORD = "password";
+static constexpr uint8_t MAX_HTTP_PASSWORD_LEN = 64;
 
 static String      hostname;
 static String      token;
+static String      httpPassword;
 static WebServer*  httpServer       = nullptr;
 static bool        started          = false;
 static bool        markedValid      = false;
 static uint32_t    sanityDeadline   = 0;
 static bool        sawValidFrame    = false;
 
+static String modemTitle() {
+    return String(BOARD.name) + " LoRa Modem";
+}
+
+static String currentIPString() {
+    if (EthernetManager::hasIP()) return String(EthernetManager::getIPString());
+    return WiFi.localIP().toString();
+}
+
+static void loadHttpPassword() {
+    httpPassword = DEFAULT_HTTP_PASSWORD;
+    Preferences p;
+    if (p.begin(NVS_NAMESPACE, true)) {
+        httpPassword = p.getString(HTTP_PASS_KEY, DEFAULT_HTTP_PASSWORD);
+        p.end();
+    }
+    if (httpPassword.length() == 0) {
+        httpPassword = DEFAULT_HTTP_PASSWORD;
+    }
+}
+
+static bool saveHttpPassword(const String& password) {
+    Preferences p;
+    if (!p.begin(NVS_NAMESPACE, false)) return false;
+    size_t written = p.putString(HTTP_PASS_KEY, password);
+    p.end();
+    if (written == 0) return false;
+    httpPassword = password;
+    return true;
+}
 // ─── Rollback sanity check ──────────────────────────────────
 //
 // When ESP-IDF boots from a newly-written slot, otadata marks it as
@@ -55,7 +92,7 @@ static void attemptMarkValid() {
     markedValid = true;
 }
 
-// ─── HTTP POST /update handler ──────────────────────────────
+// ─── HTTP auth + handlers ───────────────────────────────────
 static bool checkAuth() {
     // LAN-only policy first: drop any client whose source IP is
     // outside RFC1918 / link-local / loopback. Same rule as the
@@ -70,9 +107,9 @@ static bool checkAuth() {
                          "Forbidden: pymc_usb modem accepts LAN clients only.\n");
         return false;
     }
-    if (token.length() == 0) return true;  // open — matches TCP "no-auth" mode
-    if (!httpServer->authenticate("heltec", token.c_str())) {
-        httpServer->requestAuthentication(BASIC_AUTH, "Heltec LoRa Modem");
+    if (httpPassword.length() == 0) httpPassword = DEFAULT_HTTP_PASSWORD;
+    if (!httpServer->authenticate(HTTP_AUTH_USER, httpPassword.c_str())) {
+        httpServer->requestAuthentication(BASIC_AUTH, modemTitle().c_str());
         return false;
     }
     return true;
@@ -80,16 +117,23 @@ static bool checkAuth() {
 
 static void handleRoot() {
     if (!checkAuth()) return;
+    String title = modemTitle();
     String body;
-    body.reserve(1024);
+    body.reserve(2048);
     body += F("<!DOCTYPE html><html><head><meta charset='utf-8'>"
-              "<title>Heltec LoRa Modem</title>"
+              "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+              "<title>");
+    body += title;
+    body += F("</title>"
               "<style>body{font-family:system-ui,sans-serif;max-width:540px;"
               "margin:1em auto;padding:0 1em;color:#222}"
-              "input[type=file]{margin:1em 0}"
-              "button{padding:.6em 1em;background:#3a7;color:#fff;border:0;border-radius:4px}"
-              ".m{color:#666;font-size:.9em}</style></head><body>");
-    body += F("<h2>Heltec LoRa Modem</h2>");
+              "input{width:100%;padding:.5em;box-sizing:border-box;font-size:1em}"
+              "input[type=file]{margin:1em 0;padding:.5em 0}"
+              "button{margin-top:.8em;padding:.6em 1em;background:#3a7;color:#fff;border:0;border-radius:4px}"
+              ".m{color:#666;font-size:.9em}"
+              "hr{margin:2em 0;border:0;border-top:1px solid #ddd}"
+              "label{display:block;margin-top:.9em;font-weight:600}</style></head><body>");
+    body += "<h2>" + title + "</h2>";
     body += "<p class='m'>mDNS: <b>" + hostname + ".local</b> &nbsp; IP: <b>" +
             WiFi.localIP().toString() + "</b></p>";
     body += F("<h3>OTA update</h3>"
@@ -98,9 +142,56 @@ static void handleRoot() {
               "<br><button type='submit'>Upload firmware.bin</button>"
               "</form>"
               "<p class='m'>CLI alternative: "
-              "<code>curl -F firmware=@firmware.bin http://");
-    body += hostname + ".local/update</code></p>";
+              "<code>curl -u admin:&lt;password&gt; -F firmware=@firmware.bin http://");
+    body += hostname + ".local/update</code></p>"
+            "<hr>"
+            "<h3>HTTP password</h3>"
+            "<form method='POST' action='/auth'>"
+            "<label>New password</label>"
+            "<input type='password' name='password' autocomplete='new-password' "
+            "required minlength='1' maxlength='64'>"
+            "<label>Confirm password</label>"
+            "<input type='password' name='confirm' autocomplete='new-password' "
+            "required minlength='1' maxlength='64'>"
+            "<button type='submit'>Save password</button>"
+            "</form>"
+            "<p class='m'>Username: <b>admin</b>. Password changes take effect on the next request.</p>";
     body += F("</body></html>");
+    httpServer->send(200, "text/html; charset=utf-8", body);
+}
+
+static void handleAuthSave() {
+    if (!checkAuth()) return;
+
+    String password = httpServer->arg("password");
+    String confirm  = httpServer->arg("confirm");
+    if (password.length() == 0 || password.length() > MAX_HTTP_PASSWORD_LEN) {
+        httpServer->send(400, "text/plain", "Password must be 1-64 characters.\n");
+        return;
+    }
+    if (password != confirm) {
+        httpServer->send(400, "text/plain", "Password confirmation does not match.\n");
+        return;
+    }
+    if (!saveHttpPassword(password)) {
+        httpServer->send(500, "text/plain", "Failed to save password.\n");
+        return;
+    }
+    if (token.length() == 0) {
+        ArduinoOTA.setPassword(httpPassword.c_str());
+    }
+    Serial.printf("[OTA] HTTP password changed by %s\n",
+                  httpServer->client().remoteIP().toString().c_str());
+
+    String body = F("<!DOCTYPE html><html><head><meta charset='utf-8'>"
+                    "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+                    "<title>Password saved</title></head>"
+                    "<body style='font-family:system-ui,sans-serif;max-width:540px;"
+                    "margin:2em auto;padding:0 1em;color:#222'>"
+                    "<h2>Password saved</h2>"
+                    "<p>Use the new password the next time this page asks for credentials.</p>"
+                    "<p><a href='/'>Back to OTA page</a></p>"
+                    "</body></html>");
     httpServer->send(200, "text/html; charset=utf-8", body);
 }
 
@@ -154,6 +245,8 @@ static void configureArduinoOTA() {
     ArduinoOTA.setHostname(hostname.c_str());
     if (token.length() > 0) {
         ArduinoOTA.setPassword(token.c_str());
+    } else {
+        ArduinoOTA.setPassword(httpPassword.c_str());
     }
     ArduinoOTA.onStart([]() {
         Serial.println("[OTA/Arduino] start");
@@ -172,6 +265,7 @@ void begin(const String& hn, const String& tk) {
     if (started) return;
     hostname = hn;
     token    = tk;
+    loadHttpPassword();
 
     if (!MDNS.begin(hostname.c_str())) {
         Serial.println("[OTA] mDNS start failed");
@@ -185,6 +279,7 @@ void begin(const String& hn, const String& tk) {
 
     httpServer = new WebServer(HTTP_PORT);
     httpServer->on("/",       HTTP_GET,  handleRoot);
+    httpServer->on("/auth",   HTTP_POST, handleAuthSave);
     httpServer->on("/update", HTTP_POST, handleUpdateResult, handleUpdateUpload);
     httpServer->onNotFound([]() { httpServer->send(404, "text/plain", "Not found"); });
     httpServer->begin();
@@ -194,9 +289,16 @@ void begin(const String& hn, const String& tk) {
     markedValid    = false;
     started        = true;
 
+<<<<<<< HEAD
     Serial.printf("[OTA] HTTP /update + ArduinoOTA ready on %s (%s)\n",
                   WiFi.localIP().toString().c_str(),
                   token.length() > 0 ? "auth: token" : "auth: open");
+=======
+    Serial.printf("[OTA] HTTP /update + ArduinoOTA ready on %s (http auth: %s, arduino ota: %s)\n",
+                  currentIPString().c_str(),
+                  HTTP_AUTH_USER,
+                  token.length() > 0 ? "tcp token" : "http password");
+>>>>>>> 55b393d (firmware: require auth for OTA web page)
 }
 
 void loop() {

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -4,6 +4,7 @@
 // =============================================================
 #include "ota_manager.h"
 #include "net_filter.h"
+#include "wifi_manager.h"
 
 #include <ArduinoOTA.h>
 #include <ESPmDNS.h>
@@ -118,8 +119,9 @@ static bool checkAuth() {
 static void handleRoot() {
     if (!checkAuth()) return;
     String title = modemTitle();
+    const auto& cfg = WifiManager::getConfig();
     String body;
-    body.reserve(2048);
+    body.reserve(3072);
     body += F("<!DOCTYPE html><html><head><meta charset='utf-8'>"
               "<meta name='viewport' content='width=device-width,initial-scale=1'>"
               "<title>");
@@ -145,6 +147,16 @@ static void handleRoot() {
               "<code>curl -u admin:&lt;password&gt; -F firmware=@firmware.bin http://");
     body += hostname + ".local/update</code></p>"
             "<hr>"
+            "<h3>Hostname</h3>"
+            "<form method='POST' action='/hostname'>"
+            "<label>mDNS / OTA hostname</label>"
+            "<input type='text' name='hostname' autocomplete='off' maxlength='32' value='" +
+            cfg.hostname +
+            "' placeholder='leave blank for default'>"
+            "<button type='submit'>Save hostname</button>"
+            "</form>"
+            "<p class='m'>Blank resets to the board default. Reboot required.</p>"
+            "<hr>"
             "<h3>HTTP password</h3>"
             "<form method='POST' action='/auth'>"
             "<label>New password</label>"
@@ -158,6 +170,33 @@ static void handleRoot() {
             "<p class='m'>Username: <b>admin</b>. Password changes take effect on the next request.</p>";
     body += F("</body></html>");
     httpServer->send(200, "text/html; charset=utf-8", body);
+}
+
+static void handleHostnameSave() {
+    if (!checkAuth()) return;
+
+    WifiManager::Config cfg = WifiManager::getConfig();
+    String requested = httpServer->arg("hostname");
+    requested.trim();
+    cfg.hostname = requested;
+    WifiManager::saveConfig(cfg);
+
+    Serial.printf("[OTA] hostname updated by %s -> '%s'\n",
+                  httpServer->client().remoteIP().toString().c_str(),
+                  requested.c_str());
+
+    String body = F("<!DOCTYPE html><html><head><meta charset='utf-8'>"
+                    "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+                    "<title>Hostname saved</title></head>"
+                    "<body style='font-family:system-ui,sans-serif;max-width:540px;"
+                    "margin:2em auto;padding:0 1em;color:#222'>"
+                    "<h2>Hostname saved</h2>"
+                    "<p>The modem will reboot now and come back with the updated hostname.</p>"
+                    "<p><a href='/'>Back to OTA page</a></p>"
+                    "</body></html>");
+    httpServer->send(200, "text/html; charset=utf-8", body);
+    delay(500);
+    ESP.restart();
 }
 
 static void handleAuthSave() {
@@ -279,6 +318,7 @@ void begin(const String& hn, const String& tk) {
 
     httpServer = new WebServer(HTTP_PORT);
     httpServer->on("/",       HTTP_GET,  handleRoot);
+    httpServer->on("/hostname", HTTP_POST, handleHostnameSave);
     httpServer->on("/auth",   HTTP_POST, handleAuthSave);
     httpServer->on("/update", HTTP_POST, handleUpdateResult, handleUpdateUpload);
     httpServer->onNotFound([]() { httpServer->send(404, "text/plain", "Not found"); });

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -3,14 +3,20 @@
 // dual-bank rollback guarded by a sanity watchdog.
 // =============================================================
 #include "ota_manager.h"
+#include "board_config.h"
+#include "ethernet_manager.h"
 #include "net_filter.h"
+#include "runtime_stats.h"
+#include "tcp_server.h"
 #include "wifi_manager.h"
 
+#include <ArduinoJson.h>
 #include <ArduinoOTA.h>
 #include <ESPmDNS.h>
 #include <Preferences.h>
 #include <Update.h>
 #include <WebServer.h>
+#include <ETH.h>
 #include <WiFi.h>
 #include <esp_ota_ops.h>
 
@@ -88,6 +94,406 @@ static IPAddress parseIPArg(const String& s) {
     if (!ip.fromString(s)) ip = IPAddress((uint32_t)0);
     return ip;
 }
+
+struct NetworkSnapshot {
+    const char* iface = "Offline";
+    bool live = false;
+    IPAddress ip;
+    IPAddress subnet;
+    IPAddress gateway;
+    IPAddress dns1;
+    IPAddress dns2;
+};
+
+static NetworkSnapshot getNetworkSnapshot() {
+    NetworkSnapshot snap;
+    if (EthernetManager::hasIP()) {
+        snap.iface = "Ethernet";
+        snap.live = true;
+        snap.ip = ETH.localIP();
+        snap.subnet = ETH.subnetMask();
+        snap.gateway = ETH.gatewayIP();
+        snap.dns1 = ETH.dnsIP(0);
+        snap.dns2 = ETH.dnsIP(1);
+        return snap;
+    }
+    if (WifiManager::isSTAConnected()) {
+        snap.iface = "Wi-Fi";
+        snap.live = true;
+        snap.ip = WiFi.localIP();
+        snap.subnet = WiFi.subnetMask();
+        snap.gateway = WiFi.gatewayIP();
+        snap.dns1 = WiFi.dnsIP(0);
+        snap.dns2 = WiFi.dnsIP(1);
+        return snap;
+    }
+    if (WifiManager::isAPActive()) {
+        snap.iface = "Setup AP";
+        snap.live = true;
+        snap.ip = WiFi.softAPIP();
+    }
+    return snap;
+}
+
+static String ipFieldValue(bool useStatic, const IPAddress& saved, const IPAddress& live) {
+    if (useStatic && (uint32_t)saved != 0) return saved.toString();
+    if (!useStatic && (uint32_t)live != 0) return live.toString();
+    if ((uint32_t)saved != 0) return saved.toString();
+    return String();
+}
+
+static String formatUptime(uint32_t uptimeSec) {
+    uint32_t days = uptimeSec / 86400;
+    uint32_t hours = (uptimeSec % 86400) / 3600;
+    uint32_t minutes = (uptimeSec % 3600) / 60;
+    uint32_t seconds = uptimeSec % 60;
+    char buf[32];
+    if (days > 0) {
+        snprintf(buf, sizeof(buf), "%lud %02lu:%02lu:%02lu",
+                 (unsigned long)days, (unsigned long)hours,
+                 (unsigned long)minutes, (unsigned long)seconds);
+    } else {
+        snprintf(buf, sizeof(buf), "%02lu:%02lu:%02lu",
+                 (unsigned long)hours, (unsigned long)minutes,
+                 (unsigned long)seconds);
+    }
+    return String(buf);
+}
+
+static const char* radioStateLabel(const RuntimeStats::Snapshot& snap) {
+    if (snap.radioStandby) return "Standby";
+    switch (snap.status.radio_state) {
+        case 1: return "TX";
+        case 2: return "Error";
+        default: return "RX/Idle";
+    }
+}
+
+static String htmlEscape(const String& value) {
+    String out;
+    out.reserve(value.length() + 8);
+    for (size_t i = 0; i < value.length(); ++i) {
+        switch (value[i]) {
+            case '&': out += F("&amp;"); break;
+            case '<': out += F("&lt;"); break;
+            case '>': out += F("&gt;"); break;
+            default: out += value[i]; break;
+        }
+    }
+    return out;
+}
+
+static String jsonEscape(const String& value) {
+    String out;
+    out.reserve(value.length() + 8);
+    for (size_t i = 0; i < value.length(); ++i) {
+        switch (value[i]) {
+            case '\"': out += F("\\\""); break;
+            case '\\': out += F("\\\\"); break;
+            case '\n': out += F("\\n"); break;
+            case '\r': out += F("\\r"); break;
+            case '\t': out += F("\\t"); break;
+            default: out += value[i]; break;
+        }
+    }
+    return out;
+}
+
+static String jsonQuote(const String& value) {
+    return String("\"") + jsonEscape(value) + "\"";
+}
+
+static String boolJson(bool value) {
+    return value ? String("true") : String("false");
+}
+
+static String ipJson(const IPAddress& ip) {
+    return (uint32_t)ip != 0 ? jsonQuote(ip.toString()) : String("null");
+}
+
+static void sendJson(int code, const String& body) {
+    httpServer->send(code, "application/json; charset=utf-8", body);
+}
+
+static void sendJsonError(int code, const String& message) {
+    sendJson(code, String("{\"error\":") + jsonQuote(message) + "}");
+}
+
+static String buildSystemJson(const RuntimeStats::Snapshot& snap,
+                              const NetworkSnapshot& net,
+                              const String& clientIP) {
+    String body;
+    body.reserve(512);
+    body += F("{\"board\":");
+    body += jsonQuote(BOARD.name);
+    body += F(",\"firmware\":");
+    body += jsonQuote(snap.firmwareVersion);
+    body += F(",\"hostname\":");
+    body += jsonQuote(hostname);
+    body += F(",\"mdns\":");
+    body += jsonQuote(hostname + ".local");
+    body += F(",\"interface\":");
+    body += jsonQuote(net.iface);
+    body += F(",\"current_ip\":");
+    body += jsonQuote(currentIPString());
+    body += F(",\"connected_client_ip\":");
+    body += clientIP.length() > 0 ? jsonQuote(clientIP) : String("null");
+    body += F(",\"uptime_sec\":");
+    body += String(snap.status.uptime_sec);
+    body += F(",\"uptime\":");
+    body += jsonQuote(formatUptime(snap.status.uptime_sec));
+    body += F(",\"die_temperature_c\":");
+    body += String(snap.status.temp_c);
+    body += F("}");
+    return body;
+}
+
+static String buildRadioJson(const RuntimeStats::Snapshot& snap) {
+    String body;
+    body.reserve(512);
+    body += F("{\"state\":");
+    body += jsonQuote(radioStateLabel(snap));
+    body += F(",\"standby\":");
+    body += boolJson(snap.radioStandby);
+    body += F(",\"auto_cad_enabled\":");
+    body += boolJson(snap.autoCadEnabled);
+    body += F(",\"frequency_hz\":");
+    body += String(snap.radio.freq_hz);
+    body += F(",\"frequency_mhz\":");
+    body += String(snap.radio.freq_hz / 1000000.0f, 3);
+    body += F(",\"bandwidth_hz\":");
+    body += String(snap.radio.bandwidth_hz);
+    body += F(",\"bandwidth_khz\":");
+    body += String(snap.radio.bandwidth_hz / 1000.0f, 1);
+    body += F(",\"spreading_factor\":");
+    body += String(snap.radio.sf);
+    body += F(",\"coding_rate\":");
+    body += String(snap.radio.cr);
+    body += F(",\"tx_power_dbm\":");
+    body += String(snap.radio.power_dbm);
+    body += F(",\"syncword\":");
+    body += jsonQuote(String("0x") + String(snap.radio.syncword, HEX));
+    body += F(",\"syncword_value\":");
+    body += String(snap.radio.syncword);
+    body += F(",\"preamble_len\":");
+    body += String(snap.radio.preamble_len);
+    body += F("}");
+    return body;
+}
+
+static String buildCountersJson(const RuntimeStats::Snapshot& snap) {
+    String body;
+    body.reserve(256);
+    body += F("{\"rx_packets\":");
+    body += String(snap.status.rx_count);
+    body += F(",\"tx_packets\":");
+    body += String(snap.status.tx_count);
+    body += F(",\"crc_errors\":");
+    body += String(snap.status.crc_errors);
+    body += F(",\"last_rssi_dbm\":");
+    body += String(snap.status.last_rssi);
+    body += F(",\"last_snr_db\":");
+    body += String(snap.status.last_snr / 10.0f, 1);
+    body += F(",\"noise_floor_dbm\":");
+    body += String(snap.status.noise_floor_x10 / 10.0f, 1);
+    body += F("}");
+    return body;
+}
+
+static String buildNetworkJson(const WifiManager::Config& cfg,
+                               const NetworkSnapshot& net) {
+    String body;
+    body.reserve(768);
+    body += F("{\"mode\":");
+    body += jsonQuote(cfg.useStaticIP ? "static" : "dhcp");
+    body += F(",\"use_static_ip\":");
+    body += boolJson(cfg.useStaticIP);
+    body += F(",\"interface\":");
+    body += jsonQuote(net.iface);
+    body += F(",\"live\":");
+    body += boolJson(net.live);
+    body += F(",\"current_ip\":");
+    body += jsonQuote(currentIPString());
+    body += F(",\"subnet\":");
+    body += ipJson(net.subnet);
+    body += F(",\"gateway\":");
+    body += ipJson(net.gateway);
+    body += F(",\"dns1\":");
+    body += ipJson(net.dns1);
+    body += F(",\"dns2\":");
+    body += ipJson(net.dns2);
+    body += F(",\"tcp_port\":");
+    body += String(cfg.tcpPort);
+    body += F(",\"pymc_token_set\":");
+    body += boolJson(cfg.tcpToken.length() > 0);
+    body += F(",\"saved\":{");
+    body += F("\"static_ip\":");
+    body += ipJson(cfg.staticIP);
+    body += F(",\"subnet\":");
+    body += ipJson(cfg.subnet);
+    body += F(",\"gateway\":");
+    body += ipJson(cfg.gateway);
+    body += F(",\"dns1\":");
+    body += ipJson(cfg.dns1);
+    body += F(",\"dns2\":");
+    body += ipJson(cfg.dns2);
+    body += F("}}");
+    return body;
+}
+
+static String buildConfigJson(const WifiManager::Config& cfg) {
+    String body;
+    body.reserve(512);
+    body += F("{\"hostname\":");
+    body += jsonQuote(cfg.hostname);
+    body += F(",\"effective_hostname\":");
+    body += jsonQuote(hostname);
+    body += F(",\"tcp_token\":");
+    body += jsonQuote(cfg.tcpToken);
+    body += F(",\"tcp_port\":");
+    body += String(cfg.tcpPort);
+    body += F(",\"use_static_ip\":");
+    body += boolJson(cfg.useStaticIP);
+    body += F(",\"static_ip\":");
+    body += ipJson(cfg.staticIP);
+    body += F(",\"subnet\":");
+    body += ipJson(cfg.subnet);
+    body += F(",\"gateway\":");
+    body += ipJson(cfg.gateway);
+    body += F(",\"dns1\":");
+    body += ipJson(cfg.dns1);
+    body += F(",\"dns2\":");
+    body += ipJson(cfg.dns2);
+    body += F("}");
+    return body;
+}
+
+static String buildStatsJson(const RuntimeStats::Snapshot& snap,
+                             const WifiManager::Config& cfg,
+                             const NetworkSnapshot& net,
+                             const String& clientIP) {
+    String body;
+    body.reserve(2048);
+    body += F("{\"system\":");
+    body += buildSystemJson(snap, net, clientIP);
+    body += F(",\"radio\":");
+    body += buildRadioJson(snap);
+    body += F(",\"counters\":");
+    body += buildCountersJson(snap);
+    body += F(",\"network\":");
+    body += buildNetworkJson(cfg, net);
+    body += F("}");
+    return body;
+}
+
+static bool parseJsonIp(JsonVariantConst value, IPAddress& ip, const char* field, String& error) {
+    if (value.isNull()) {
+        ip = IPAddress((uint32_t)0);
+        return true;
+    }
+    if (!value.is<const char*>()) {
+        error = String(field) + " must be a string IP address.";
+        return false;
+    }
+    String raw = value.as<const char*>();
+    raw.trim();
+    if (raw.length() == 0) {
+        ip = IPAddress((uint32_t)0);
+        return true;
+    }
+    if (!ip.fromString(raw)) {
+        error = String(field) + " is not a valid IPv4 address.";
+        return false;
+    }
+    return true;
+}
+
+static bool applyConfigPatch(JsonVariantConst root, WifiManager::Config& cfg, String& error) {
+    if (!root.is<JsonObjectConst>()) {
+        error = "JSON body must be an object.";
+        return false;
+    }
+
+    JsonObjectConst obj = root.as<JsonObjectConst>();
+
+    JsonVariantConst hostVal = obj["hostname"];
+    if (!hostVal.isNull()) {
+        if (!hostVal.is<const char*>()) {
+            error = "hostname must be a string.";
+            return false;
+        }
+        cfg.hostname = String(hostVal.as<const char*>());
+        cfg.hostname.trim();
+    }
+
+    JsonVariantConst tokenVal = obj["tcp_token"];
+    if (!tokenVal.isNull()) {
+        if (!tokenVal.is<const char*>()) {
+            error = "tcp_token must be a string.";
+            return false;
+        }
+        cfg.tcpToken = String(tokenVal.as<const char*>());
+        if (cfg.tcpToken.length() > MAX_TCP_TOKEN_LEN) {
+            error = "tcp_token must be 0-64 characters.";
+            return false;
+        }
+    }
+
+    JsonVariantConst portVal = obj["tcp_port"];
+    if (!portVal.isNull()) {
+        if (!portVal.is<uint16_t>()) {
+            error = "tcp_port must be an integer.";
+            return false;
+        }
+        cfg.tcpPort = portVal.as<uint16_t>();
+        if (cfg.tcpPort == 0) {
+            error = "tcp_port must be between 1 and 65535.";
+            return false;
+        }
+    }
+
+    JsonVariantConst staticVal = obj["use_static_ip"];
+    if (!staticVal.isNull()) {
+        if (!staticVal.is<bool>()) {
+            error = "use_static_ip must be true or false.";
+            return false;
+        }
+        cfg.useStaticIP = staticVal.as<bool>();
+    }
+
+    JsonVariantConst networkVal = obj["network"];
+    if (!networkVal.isNull()) {
+        if (!networkVal.is<JsonObjectConst>()) {
+            error = "network must be an object.";
+            return false;
+        }
+        JsonObjectConst network = networkVal.as<JsonObjectConst>();
+
+        JsonVariantConst nestedStaticVal = network["use_static_ip"];
+        if (!nestedStaticVal.isNull()) {
+            if (!nestedStaticVal.is<bool>()) {
+                error = "network.use_static_ip must be true or false.";
+                return false;
+            }
+            cfg.useStaticIP = nestedStaticVal.as<bool>();
+        }
+
+        if (!parseJsonIp(network["static_ip"], cfg.staticIP, "network.static_ip", error)) return false;
+        if (!parseJsonIp(network["subnet"], cfg.subnet, "network.subnet", error)) return false;
+        if (!parseJsonIp(network["gateway"], cfg.gateway, "network.gateway", error)) return false;
+        if (!parseJsonIp(network["dns1"], cfg.dns1, "network.dns1", error)) return false;
+        if (!parseJsonIp(network["dns2"], cfg.dns2, "network.dns2", error)) return false;
+    }
+
+    if (cfg.useStaticIP &&
+        (((uint32_t)cfg.staticIP == 0) || ((uint32_t)cfg.subnet == 0) || ((uint32_t)cfg.gateway == 0))) {
+        error = "static_ip, subnet, and gateway are required when use_static_ip is true.";
+        return false;
+    }
+
+    return true;
+}
+
 // ─── Rollback sanity check ──────────────────────────────────
 //
 // When ESP-IDF boots from a newly-written slot, otadata marks it as
@@ -145,87 +551,278 @@ static void handleRoot() {
     if (!checkAuth()) return;
     String title = modemTitle();
     const auto& cfg = WifiManager::getConfig();
+    String clientIP = TCPServer::getClientIP();
+    NetworkSnapshot net = getNetworkSnapshot();
+    String ipValue = ipFieldValue(cfg.useStaticIP, cfg.staticIP, net.ip);
+    String subnetValue = ipFieldValue(cfg.useStaticIP, cfg.subnet, net.subnet);
+    String gatewayValue = ipFieldValue(cfg.useStaticIP, cfg.gateway, net.gateway);
+    String dns1Value = ipFieldValue(cfg.useStaticIP, cfg.dns1, net.dns1);
+    String dns2Value = ipFieldValue(cfg.useStaticIP, cfg.dns2, net.dns2);
+    String leaseHint;
+    if (cfg.useStaticIP) {
+        leaseHint = "Static mode is saved. These values are what the modem will use after reboot.";
+    } else if (net.live) {
+        leaseHint = "DHCP is active. These fields show the live lease from ";
+        leaseHint += net.iface;
+        leaseHint += ".";
+    } else {
+        leaseHint = "DHCP is active. No live lease is available yet, so the fields are blank.";
+    }
     String body;
-    body.reserve(3072);
+    body.reserve(8192);
     body += F("<!DOCTYPE html><html><head><meta charset='utf-8'>"
               "<meta name='viewport' content='width=device-width,initial-scale=1'>"
               "<title>");
     body += title;
     body += F("</title>"
-              "<style>body{font-family:system-ui,sans-serif;max-width:540px;"
-              "margin:1em auto;padding:0 1em;color:#222}"
-              "input{width:100%;padding:.5em;box-sizing:border-box;font-size:1em}"
-              "input[type=file]{margin:1em 0;padding:.5em 0}"
-              "button{margin-top:.8em;padding:.6em 1em;background:#3a7;color:#fff;border:0;border-radius:4px}"
-              ".m{color:#666;font-size:.9em}"
-              "hr{margin:2em 0;border:0;border-top:1px solid #ddd}"
-              "label{display:block;margin-top:.9em;font-weight:600}</style></head><body>");
+              "<style>body{font-family:system-ui,sans-serif;max-width:760px;margin:1.25em auto;padding:0 1em;color:#222;line-height:1.45}"
+              "h2{margin:.2em 0 .35em}p{margin:.45em 0}.m{color:#666;font-size:.92em}"
+              ".summary{background:#f7f7f7;border:1px solid #ddd;border-radius:8px;padding:.8em 1em;margin:1em 0 1.2em}"
+              ".summary strong{display:inline-block;min-width:4.5em}.chips{margin-top:.55em}"
+              ".chip{display:inline-block;background:#efefef;border:1px solid #ddd;border-radius:999px;padding:.2em .6em;margin:0 .35em .35em 0;font-size:.9em}"
+              "details{border:1px solid #ddd;border-radius:8px;padding:.65em .8em;margin:0 0 .9em;background:#fff}"
+              "summary{cursor:pointer;font-weight:700;list-style:none}summary::-webkit-details-marker{display:none}"
+              ".inside{margin-top:.8em}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75em 1em}"
+              "label{display:block;margin-top:.8em;font-weight:600}input{width:100%;padding:.55em;box-sizing:border-box;font-size:1em;border:1px solid #ccc;border-radius:6px}"
+              "input[type=file]{padding:.3em 0;border:0}input[type=checkbox]{width:auto;margin-right:.45em}"
+              ".checkline{display:flex;align-items:center;gap:.35em;margin-top:.8em}button{margin-top:.9em;padding:.6em 1em;background:#2f6f5e;color:#fff;border:0;border-radius:6px;cursor:pointer}"
+              "code{font-family:ui-monospace,SFMono-Regular,monospace;background:#f3f3f3;padding:.1em .35em;border-radius:4px}"
+              "@media (max-width:640px){body{padding:0 .75em}}</style></head><body>");
     body += "<h2>" + title + "</h2>";
-    body += "<p class='m'>mDNS: <b>" + hostname + ".local</b> &nbsp; IP: <b>" +
-            WiFi.localIP().toString() + "</b></p>";
-    body += F("<h3>OTA update</h3>"
+    body += "<div class='summary'><p><strong>mDNS</strong> " + hostname + ".local</p>";
+    body += "<p><strong>IP</strong> " + currentIPString() + "</p>";
+    body += "<p><strong>Interface</strong> ";
+    body += net.iface;
+    body += "</p><p><strong>Current connection</strong> ";
+    body += clientIP.length() > 0 ? clientIP : String("none");
+    body += "</p><div class='chips'><span class='chip'>";
+    body += cfg.tcpToken.length() > 0 ? "pyMC protected" : "pyMC open";
+    body += "</span><span class='chip'>";
+    body += cfg.useStaticIP ? "Static network saved" : "DHCP mode";
+    body += F("</span></div><p class='m'><a href='/stats'>View stats page</a></p></div>");
+
+    body += F("<details open><summary>OTA Update</summary><div class='inside'>"
+              "<p>Upload an app-only <code>firmware.bin</code> over the LAN.</p>"
               "<form method='POST' action='/update' enctype='multipart/form-data'>"
-              "<input type='file' name='firmware' accept='.bin' required>"
-              "<br><button type='submit'>Upload firmware.bin</button>"
-              "</form>"
-              "<p class='m'>CLI alternative: "
-              "<code>curl -u admin:&lt;password&gt; -F firmware=@firmware.bin http://");
-    body += hostname + ".local/update</code></p>";
-    body += F("<hr>"
-              "<h3>Hostname</h3>"
+              "<input type='file' name='firmware' accept='.bin' required><br>"
+              "<button type='submit'>Upload firmware.bin</button>"
+              "</form><p class='m'>CLI alternative: <code>curl -u admin:&lt;password&gt; -F firmware=@firmware.bin http://");
+    body += hostname + ".local/update</code></p></div></details>";
+
+    body += F("<details><summary>Hostname</summary><div class='inside'>"
+              "<p>Controls the mDNS / OTA hostname the modem advertises on the network.</p>"
               "<form method='POST' action='/hostname'>"
               "<label>mDNS / OTA hostname</label>");
     body += "<input type='text' name='hostname' autocomplete='off' maxlength='32' value='" +
             cfg.hostname +
             "' placeholder='leave blank for default'>";
     body += F("<button type='submit'>Save hostname</button>"
-              "</form>"
-              "<p class='m'>Blank resets to the board default. Reboot required.</p>"
-              "<hr>"
-              "<h3>Network</h3>"
-              "<form method='POST' action='/network'>");
-    body += F("<label><input type='checkbox' name='static' value='1'");
+              "</form><p class='m'>Blank resets to the board default. Reboot required.</p></div></details>");
+
+    body += F("<details><summary>Network</summary><div class='inside'><p>");
+    body += leaseHint;
+    body += F("</p><form method='POST' action='/network'><div class='checkline'><input type='checkbox' id='static' name='static' value='1'");
     if (cfg.useStaticIP) body += F(" checked");
-    body += F("> Use static IP (otherwise DHCP)</label>"
-              "<label>Static IP</label>");
-    body += "<input type='text' name='ip' value='" + cfg.staticIP.toString() + "' placeholder='192.168.1.42'>";
-    body += F("<label>Subnet mask</label>");
-    body += "<input type='text' name='sn' value='" + cfg.subnet.toString() + "' placeholder='255.255.255.0'>";
-    body += F("<label>Gateway</label>");
-    body += "<input type='text' name='gw' value='" + cfg.gateway.toString() + "' placeholder='192.168.1.1'>";
-    body += F("<label>DNS 1</label>");
-    body += "<input type='text' name='dns1' value='" + cfg.dns1.toString() + "' placeholder='1.1.1.1'>";
-    body += F("<label>DNS 2</label>");
-    body += "<input type='text' name='dns2' value='" + cfg.dns2.toString() + "' placeholder='8.8.8.8'>";
-    body += F("<button type='submit'>Save network settings</button>"
-              "</form>"
-              "<p class='m'>Default is DHCP. Static settings apply after reboot.</p>"
-              "<hr>");
-    body += F("<h3>pyMC Token</h3>"
+    body += F("><label for='static'>Use static IP instead of DHCP</label></div><div class='grid'>");
+    body += "<div><label>Static IP</label><input type='text' name='ip' value='" + ipValue + "' placeholder='192.168.1.42'></div>";
+    body += "<div><label>Subnet mask</label><input type='text' name='sn' value='" + subnetValue + "' placeholder='255.255.255.0'></div>";
+    body += "<div><label>Gateway</label><input type='text' name='gw' value='" + gatewayValue + "' placeholder='192.168.1.1'></div>";
+    body += "<div><label>DNS 1</label><input type='text' name='dns1' value='" + dns1Value + "' placeholder='1.1.1.1'></div>";
+    body += "<div><label>DNS 2</label><input type='text' name='dns2' value='" + dns2Value + "' placeholder='8.8.8.8'></div>";
+    body += "<div><label>Current source</label><div class='chip'>" + String(net.iface) + "</div></div>";
+    body += F("</div><button type='submit'>Save network settings</button></form></div></details>");
+
+    body += F("<details><summary>pyMC Token</summary><div class='inside'>"
+              "<p>This token must match the <code>token</code> value in pyMC so pyMC can connect to the radio.</p>"
               "<form method='POST' action='/token'>"
               "<label>New pyMC token</label>"
               "<input type='password' name='token' autocomplete='new-password' maxlength='64'>"
               "<label>Confirm pyMC token</label>"
               "<input type='password' name='confirm' autocomplete='new-password' maxlength='64'>"
               "<button type='submit'>Save pyMC token</button>"
-              "</form>");
-    body += "<p class='m'>Current mode: <b>";
-    body += cfg.tcpToken.length() > 0 ? "protected" : "open";
-    body += F("</b>. This token must match the <code>token</code> value in pyMC so pyMC can connect to the radio. Leave both fields blank to clear it. Reboot required.</p>"
-              "<hr>"
-            "<h3>HTTP password</h3>"
-            "<form method='POST' action='/auth'>"
-            "<label>New password</label>"
-            "<input type='password' name='password' autocomplete='new-password' "
-            "required minlength='1' maxlength='64'>"
-            "<label>Confirm password</label>"
-            "<input type='password' name='confirm' autocomplete='new-password' "
-            "required minlength='1' maxlength='64'>"
-            "<button type='submit'>Save password</button>"
-            "</form>"
-            "<p class='m'>Username: <b>admin</b>. Password changes take effect on the next request.</p>");
-    body += F("</body></html>");
+              "</form><p class='m'>Current mode: <span class='chip'>");
+    body += cfg.tcpToken.length() > 0 ? "Protected" : "Open";
+    body += F("</span>. Leave both fields blank to clear it. Reboot required.</p></div></details>");
+
+    body += F("<details><summary>HTTP Password</summary><div class='inside'>"
+              "<p>Protects this web page and OTA uploads. Username: <code>admin</code>.</p>"
+              "<form method='POST' action='/auth'>"
+              "<label>New password</label>"
+              "<input type='password' name='password' autocomplete='new-password' required minlength='1' maxlength='64'>"
+              "<label>Confirm password</label>"
+              "<input type='password' name='confirm' autocomplete='new-password' required minlength='1' maxlength='64'>"
+              "<button type='submit'>Save password</button>"
+              "</form><p class='m'>Password changes take effect on the next request.</p></div></details>");
+
+    body += F("<details><summary>Reboot</summary><div class='inside'>"
+              "<p>Restart the modem without changing any settings.</p>"
+              "<form method='POST' action='/reboot'>"
+              "<button type='submit'>Reboot modem</button>"
+              "</form></div></details>"
+              "</body></html>");
     httpServer->send(200, "text/html; charset=utf-8", body);
+}
+
+static void handleStats() {
+    if (!checkAuth()) return;
+
+    const auto& cfg = WifiManager::getConfig();
+    RuntimeStats::Snapshot snap = RuntimeStats::capture();
+    NetworkSnapshot net = getNetworkSnapshot();
+    String clientIP = TCPServer::getClientIP();
+    String body;
+    body.reserve(6144);
+    body += F("<!DOCTYPE html><html><head><meta charset='utf-8'>"
+              "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+              "<meta http-equiv='refresh' content='5'>"
+              "<title>Modem Stats</title>"
+              "<style>body{font-family:system-ui,sans-serif;max-width:760px;margin:1.25em auto;padding:0 1em;color:#222;line-height:1.45}"
+              "h2{margin:.2em 0 .35em}h3{margin:1.2em 0 .45em}.m{color:#666;font-size:.92em}"
+              ".card{background:#f7f7f7;border:1px solid #ddd;border-radius:8px;padding:.8em 1em;margin:1em 0}"
+              ".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75em 1em}"
+              ".kv{border:1px solid #ddd;border-radius:8px;background:#fff;padding:.7em .8em}"
+              ".k{display:block;color:#666;font-size:.9em;margin-bottom:.2em}.v{font-weight:600}"
+              ".actions{margin:1em 0}.actions a{margin-right:1em}code{font-family:ui-monospace,SFMono-Regular,monospace;background:#f3f3f3;padding:.1em .35em;border-radius:4px}"
+              "@media (max-width:640px){body{padding:0 .75em}}</style></head><body>");
+    body += "<h2>" + modemTitle() + " Stats</h2>";
+    body += F("<div class='actions'><a href='/'>Back to main page</a></div>");
+    body += F("<p class='m'>Auto-refreshes every 5 seconds.</p>");
+
+    body += F("<div class='card'><div class='grid'>");
+    body += "<div class='kv'><span class='k'>Firmware</span><span class='v'>" + htmlEscape(snap.firmwareVersion) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Hostname</span><span class='v'>" + htmlEscape(hostname) + ".local</span></div>";
+    body += "<div class='kv'><span class='k'>Current IP</span><span class='v'>" + currentIPString() + "</span></div>";
+    body += "<div class='kv'><span class='k'>Connected client</span><span class='v'>" + (clientIP.length() > 0 ? clientIP : String("none")) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Interface</span><span class='v'>" + String(net.iface) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Uptime</span><span class='v'>" + formatUptime(snap.status.uptime_sec) + "</span></div>";
+    body += "</div></div>";
+
+    body += F("<h3>Radio</h3><div class='grid'>");
+    body += "<div class='kv'><span class='k'>State</span><span class='v'>" + String(radioStateLabel(snap)) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Frequency</span><span class='v'>" + String(snap.radio.freq_hz / 1000000.0f, 3) + " MHz</span></div>";
+    body += "<div class='kv'><span class='k'>Bandwidth</span><span class='v'>" + String(snap.radio.bandwidth_hz / 1000.0f, 1) + " kHz</span></div>";
+    body += "<div class='kv'><span class='k'>Spreading factor</span><span class='v'>SF" + String(snap.radio.sf) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Coding rate</span><span class='v'>4/" + String(snap.radio.cr) + "</span></div>";
+    body += "<div class='kv'><span class='k'>TX power</span><span class='v'>" + String(snap.radio.power_dbm) + " dBm</span></div>";
+    body += "<div class='kv'><span class='k'>Syncword</span><span class='v'>0x" + String(snap.radio.syncword, HEX) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Preamble</span><span class='v'>" + String(snap.radio.preamble_len) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Auto CAD</span><span class='v'>" + String(snap.autoCadEnabled ? "On" : "Off") + "</span></div>";
+    body += "</div>";
+
+    body += F("<h3>Counters</h3><div class='grid'>");
+    body += "<div class='kv'><span class='k'>RX packets</span><span class='v'>" + String(snap.status.rx_count) + "</span></div>";
+    body += "<div class='kv'><span class='k'>TX packets</span><span class='v'>" + String(snap.status.tx_count) + "</span></div>";
+    body += "<div class='kv'><span class='k'>CRC errors</span><span class='v'>" + String(snap.status.crc_errors) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Last RSSI</span><span class='v'>" + String(snap.status.last_rssi) + " dBm</span></div>";
+    body += "<div class='kv'><span class='k'>Last SNR</span><span class='v'>" + String(snap.status.last_snr / 10.0f, 1) + " dB</span></div>";
+    body += "<div class='kv'><span class='k'>Noise floor</span><span class='v'>" + String(snap.status.noise_floor_x10 / 10.0f, 1) + " dBm</span></div>";
+    body += "<div class='kv'><span class='k'>Die temperature</span><span class='v'>" + String(snap.status.temp_c) + " C</span></div>";
+    body += "</div>";
+
+    body += F("<h3>Network</h3><div class='grid'>");
+    body += "<div class='kv'><span class='k'>Mode</span><span class='v'>" + String(cfg.useStaticIP ? "Static" : "DHCP") + "</span></div>";
+    body += "<div class='kv'><span class='k'>Port</span><span class='v'>" + String(cfg.tcpPort) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Gateway</span><span class='v'>" + ((uint32_t)net.gateway != 0 ? net.gateway.toString() : String("none")) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Subnet</span><span class='v'>" + ((uint32_t)net.subnet != 0 ? net.subnet.toString() : String("none")) + "</span></div>";
+    body += "<div class='kv'><span class='k'>DNS 1</span><span class='v'>" + ((uint32_t)net.dns1 != 0 ? net.dns1.toString() : String("none")) + "</span></div>";
+    body += "<div class='kv'><span class='k'>DNS 2</span><span class='v'>" + ((uint32_t)net.dns2 != 0 ? net.dns2.toString() : String("none")) + "</span></div>";
+    body += "</div></body></html>";
+    httpServer->send(200, "text/html; charset=utf-8", body);
+}
+
+static void handleApiTemp() {
+    if (!checkAuth()) return;
+
+    RuntimeStats::Snapshot snap = RuntimeStats::capture();
+    String body;
+    body.reserve(128);
+    body += F("{\"die_temperature_c\":");
+    body += String(snap.status.temp_c);
+    body += F(",\"firmware\":\"");
+    body += snap.firmwareVersion;
+    body += F("\",\"hostname\":\"");
+    body += hostname;
+    body += F("\"}");
+    sendJson(200, body);
+}
+
+static void handleApiSystem() {
+    if (!checkAuth()) return;
+
+    RuntimeStats::Snapshot snap = RuntimeStats::capture();
+    NetworkSnapshot net = getNetworkSnapshot();
+    sendJson(200, buildSystemJson(snap, net, TCPServer::getClientIP()));
+}
+
+static void handleApiRadio() {
+    if (!checkAuth()) return;
+
+    sendJson(200, buildRadioJson(RuntimeStats::capture()));
+}
+
+static void handleApiNetwork() {
+    if (!checkAuth()) return;
+
+    sendJson(200, buildNetworkJson(WifiManager::getConfig(), getNetworkSnapshot()));
+}
+
+static void handleApiStats() {
+    if (!checkAuth()) return;
+
+    const auto& cfg = WifiManager::getConfig();
+    RuntimeStats::Snapshot snap = RuntimeStats::capture();
+    NetworkSnapshot net = getNetworkSnapshot();
+    sendJson(200, buildStatsJson(snap, cfg, net, TCPServer::getClientIP()));
+}
+
+static void handleApiConfigGet() {
+    if (!checkAuth()) return;
+
+    sendJson(200, buildConfigJson(WifiManager::getConfig()));
+}
+
+static void handleApiConfigPost() {
+    if (!checkAuth()) return;
+
+    String raw = httpServer->arg("plain");
+    if (raw.length() == 0) {
+        sendJsonError(400, "Request body must contain JSON.");
+        return;
+    }
+
+    JsonDocument doc;
+    DeserializationError jsonError = deserializeJson(doc, raw);
+    if (jsonError) {
+        sendJsonError(400, String("Invalid JSON: ") + jsonError.c_str());
+        return;
+    }
+
+    WifiManager::Config cfg = WifiManager::getConfig();
+    String error;
+    if (!applyConfigPatch(doc.as<JsonVariantConst>(), cfg, error)) {
+        sendJsonError(400, error);
+        return;
+    }
+
+    WifiManager::saveConfig(cfg);
+
+    Serial.printf("[OTA] API config updated by %s\n",
+                  httpServer->client().remoteIP().toString().c_str());
+
+    sendJson(200, String("{\"status\":\"saved\",\"rebooting\":true,\"config\":") +
+                   buildConfigJson(cfg) + "}");
+    delay(500);
+    ESP.restart();
+}
+
+static void handleApiReboot() {
+    if (!checkAuth()) return;
+
+    Serial.printf("[OTA] API reboot requested by %s\n",
+                  httpServer->client().remoteIP().toString().c_str());
+    sendJson(200, F("{\"status\":\"rebooting\"}"));
+    delay(500);
+    ESP.restart();
 }
 
 static void handleHostnameSave() {
@@ -317,6 +914,18 @@ static void handleTokenSave() {
                    requested.length() > 0
                        ? F("The modem will reboot now and require the new pyMC token.")
                        : F("The modem will reboot now and allow open pyMC access again."));
+    delay(500);
+    ESP.restart();
+}
+
+static void handleReboot() {
+    if (!checkAuth()) return;
+
+    Serial.printf("[OTA] reboot requested by %s\n",
+                  httpServer->client().remoteIP().toString().c_str());
+    sendSimplePage(F("Rebooting"),
+                   F("Rebooting"),
+                   F("The modem will reboot now."));
     delay(500);
     ESP.restart();
 }
@@ -433,10 +1042,20 @@ void begin(const String& hn, const String& tk) {
 
     httpServer = new WebServer(HTTP_PORT);
     httpServer->on("/",       HTTP_GET,  handleRoot);
+    httpServer->on("/stats",  HTTP_GET,  handleStats);
+    httpServer->on("/api/temp", HTTP_GET, handleApiTemp);
+    httpServer->on("/api/system", HTTP_GET, handleApiSystem);
+    httpServer->on("/api/radio", HTTP_GET, handleApiRadio);
+    httpServer->on("/api/network", HTTP_GET, handleApiNetwork);
+    httpServer->on("/api/stats", HTTP_GET, handleApiStats);
+    httpServer->on("/api/config", HTTP_GET, handleApiConfigGet);
+    httpServer->on("/api/config", HTTP_POST, handleApiConfigPost);
+    httpServer->on("/api/reboot", HTTP_POST, handleApiReboot);
     httpServer->on("/hostname", HTTP_POST, handleHostnameSave);
     httpServer->on("/network", HTTP_POST, handleNetworkSave);
     httpServer->on("/token",  HTTP_POST, handleTokenSave);
     httpServer->on("/auth",   HTTP_POST, handleAuthSave);
+    httpServer->on("/reboot", HTTP_POST, handleReboot);
     httpServer->on("/update", HTTP_POST, handleUpdateResult, handleUpdateUpload);
     httpServer->onNotFound([]() { httpServer->send(404, "text/plain", "Not found"); });
     httpServer->begin();

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -23,6 +23,7 @@ static constexpr const char* HTTP_PASS_KEY  = "http_pass";
 static constexpr const char* HTTP_AUTH_USER = "admin";
 static constexpr const char* DEFAULT_HTTP_PASSWORD = "password";
 static constexpr uint8_t MAX_HTTP_PASSWORD_LEN = 64;
+static constexpr uint8_t MAX_TCP_TOKEN_LEN = 64;
 
 static String      hostname;
 static String      token;
@@ -62,6 +63,24 @@ static bool saveHttpPassword(const String& password) {
     if (written == 0) return false;
     httpPassword = password;
     return true;
+}
+
+static void sendSimplePage(const __FlashStringHelper* title,
+                           const __FlashStringHelper* heading,
+                           const __FlashStringHelper* message) {
+    String body = F("<!DOCTYPE html><html><head><meta charset='utf-8'>"
+                    "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+                    "<title>");
+    body += String(title);
+    body += F("</title></head>"
+              "<body style='font-family:system-ui,sans-serif;max-width:540px;"
+              "margin:2em auto;padding:0 1em;color:#222'>"
+              "<h2>");
+    body += String(heading);
+    body += F("</h2><p>");
+    body += String(message);
+    body += F("</p><p><a href='/'>Back to OTA page</a></p></body></html>");
+    httpServer->send(200, "text/html; charset=utf-8", body);
 }
 // ─── Rollback sanity check ──────────────────────────────────
 //
@@ -157,6 +176,18 @@ static void handleRoot() {
             "</form>"
             "<p class='m'>Blank resets to the board default. Reboot required.</p>"
             "<hr>"
+            "<h3>pyMC TCP password</h3>"
+            "<form method='POST' action='/token'>"
+            "<label>New TCP password</label>"
+            "<input type='password' name='token' autocomplete='new-password' maxlength='64'>"
+            "<label>Confirm TCP password</label>"
+            "<input type='password' name='confirm' autocomplete='new-password' maxlength='64'>"
+            "<button type='submit'>Save TCP password</button>"
+            "</form>";
+    body += "<p class='m'>Current mode: <b>";
+    body += cfg.tcpToken.length() > 0 ? "protected" : "open";
+    body += F("</b>. Leave both fields blank to clear the TCP password. Reboot required.</p>"
+              "<hr>"
             "<h3>HTTP password</h3>"
             "<form method='POST' action='/auth'>"
             "<label>New password</label>"
@@ -167,7 +198,7 @@ static void handleRoot() {
             "required minlength='1' maxlength='64'>"
             "<button type='submit'>Save password</button>"
             "</form>"
-            "<p class='m'>Username: <b>admin</b>. Password changes take effect on the next request.</p>";
+            "<p class='m'>Username: <b>admin</b>. Password changes take effect on the next request.</p>");
     body += F("</body></html>");
     httpServer->send(200, "text/html; charset=utf-8", body);
 }
@@ -199,6 +230,38 @@ static void handleHostnameSave() {
     ESP.restart();
 }
 
+static void handleTokenSave() {
+    if (!checkAuth()) return;
+
+    WifiManager::Config cfg = WifiManager::getConfig();
+    String requested = httpServer->arg("token");
+    String confirm   = httpServer->arg("confirm");
+
+    if (requested.length() > MAX_TCP_TOKEN_LEN) {
+        httpServer->send(400, "text/plain", "TCP password must be 0-64 characters.\n");
+        return;
+    }
+    if (requested != confirm) {
+        httpServer->send(400, "text/plain", "TCP password confirmation does not match.\n");
+        return;
+    }
+
+    cfg.tcpToken = requested;
+    WifiManager::saveConfig(cfg);
+
+    Serial.printf("[OTA] TCP password updated by %s -> %s\n",
+                  httpServer->client().remoteIP().toString().c_str(),
+                  requested.length() > 0 ? "set" : "cleared");
+
+    sendSimplePage(F("TCP password saved"),
+                   F("TCP password saved"),
+                   requested.length() > 0
+                       ? F("The modem will reboot now and require the new pyMC TCP password.")
+                       : F("The modem will reboot now and allow open TCP access again."));
+    delay(500);
+    ESP.restart();
+}
+
 static void handleAuthSave() {
     if (!checkAuth()) return;
 
@@ -222,16 +285,9 @@ static void handleAuthSave() {
     Serial.printf("[OTA] HTTP password changed by %s\n",
                   httpServer->client().remoteIP().toString().c_str());
 
-    String body = F("<!DOCTYPE html><html><head><meta charset='utf-8'>"
-                    "<meta name='viewport' content='width=device-width,initial-scale=1'>"
-                    "<title>Password saved</title></head>"
-                    "<body style='font-family:system-ui,sans-serif;max-width:540px;"
-                    "margin:2em auto;padding:0 1em;color:#222'>"
-                    "<h2>Password saved</h2>"
-                    "<p>Use the new password the next time this page asks for credentials.</p>"
-                    "<p><a href='/'>Back to OTA page</a></p>"
-                    "</body></html>");
-    httpServer->send(200, "text/html; charset=utf-8", body);
+    sendSimplePage(F("Password saved"),
+                   F("Password saved"),
+                   F("Use the new password the next time this page asks for credentials."));
 }
 
 static void handleUpdateResult() {
@@ -319,6 +375,7 @@ void begin(const String& hn, const String& tk) {
     httpServer = new WebServer(HTTP_PORT);
     httpServer->on("/",       HTTP_GET,  handleRoot);
     httpServer->on("/hostname", HTTP_POST, handleHostnameSave);
+    httpServer->on("/token",  HTTP_POST, handleTokenSave);
     httpServer->on("/auth",   HTTP_POST, handleAuthSave);
     httpServer->on("/update", HTTP_POST, handleUpdateResult, handleUpdateUpload);
     httpServer->onNotFound([]() { httpServer->send(404, "text/plain", "Not found"); });
@@ -329,16 +386,10 @@ void begin(const String& hn, const String& tk) {
     markedValid    = false;
     started        = true;
 
-<<<<<<< HEAD
-    Serial.printf("[OTA] HTTP /update + ArduinoOTA ready on %s (%s)\n",
-                  WiFi.localIP().toString().c_str(),
-                  token.length() > 0 ? "auth: token" : "auth: open");
-=======
     Serial.printf("[OTA] HTTP /update + ArduinoOTA ready on %s (http auth: %s, arduino ota: %s)\n",
                   currentIPString().c_str(),
                   HTTP_AUTH_USER,
                   token.length() > 0 ? "tcp token" : "http password");
->>>>>>> 55b393d (firmware: require auth for OTA web page)
 }
 
 void loop() {

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -82,6 +82,12 @@ static void sendSimplePage(const __FlashStringHelper* title,
     body += F("</p><p><a href='/'>Back to OTA page</a></p></body></html>");
     httpServer->send(200, "text/html; charset=utf-8", body);
 }
+
+static IPAddress parseIPArg(const String& s) {
+    IPAddress ip;
+    if (!ip.fromString(s)) ip = IPAddress((uint32_t)0);
+    return ip;
+}
 // ─── Rollback sanity check ──────────────────────────────────
 //
 // When ESP-IDF boots from a newly-written slot, otadata marks it as
@@ -164,26 +170,45 @@ static void handleRoot() {
               "</form>"
               "<p class='m'>CLI alternative: "
               "<code>curl -u admin:&lt;password&gt; -F firmware=@firmware.bin http://");
-    body += hostname + ".local/update</code></p>"
-            "<hr>"
-            "<h3>Hostname</h3>"
-            "<form method='POST' action='/hostname'>"
-            "<label>mDNS / OTA hostname</label>"
-            "<input type='text' name='hostname' autocomplete='off' maxlength='32' value='" +
+    body += hostname + ".local/update</code></p>";
+    body += F("<hr>"
+              "<h3>Hostname</h3>"
+              "<form method='POST' action='/hostname'>"
+              "<label>mDNS / OTA hostname</label>");
+    body += "<input type='text' name='hostname' autocomplete='off' maxlength='32' value='" +
             cfg.hostname +
-            "' placeholder='leave blank for default'>"
-            "<button type='submit'>Save hostname</button>"
-            "</form>"
-            "<p class='m'>Blank resets to the board default. Reboot required.</p>"
-            "<hr>"
-            "<h3>pyMC Token</h3>"
-            "<form method='POST' action='/token'>"
-            "<label>New pyMC token</label>"
-            "<input type='password' name='token' autocomplete='new-password' maxlength='64'>"
-            "<label>Confirm pyMC token</label>"
-            "<input type='password' name='confirm' autocomplete='new-password' maxlength='64'>"
-            "<button type='submit'>Save pyMC token</button>"
-            "</form>";
+            "' placeholder='leave blank for default'>";
+    body += F("<button type='submit'>Save hostname</button>"
+              "</form>"
+              "<p class='m'>Blank resets to the board default. Reboot required.</p>"
+              "<hr>"
+              "<h3>Network</h3>"
+              "<form method='POST' action='/network'>");
+    body += F("<label><input type='checkbox' name='static' value='1'");
+    if (cfg.useStaticIP) body += F(" checked");
+    body += F("> Use static IP (otherwise DHCP)</label>"
+              "<label>Static IP</label>");
+    body += "<input type='text' name='ip' value='" + cfg.staticIP.toString() + "' placeholder='192.168.1.42'>";
+    body += F("<label>Subnet mask</label>");
+    body += "<input type='text' name='sn' value='" + cfg.subnet.toString() + "' placeholder='255.255.255.0'>";
+    body += F("<label>Gateway</label>");
+    body += "<input type='text' name='gw' value='" + cfg.gateway.toString() + "' placeholder='192.168.1.1'>";
+    body += F("<label>DNS 1</label>");
+    body += "<input type='text' name='dns1' value='" + cfg.dns1.toString() + "' placeholder='1.1.1.1'>";
+    body += F("<label>DNS 2</label>");
+    body += "<input type='text' name='dns2' value='" + cfg.dns2.toString() + "' placeholder='8.8.8.8'>";
+    body += F("<button type='submit'>Save network settings</button>"
+              "</form>"
+              "<p class='m'>Default is DHCP. Static settings apply after reboot.</p>"
+              "<hr>");
+    body += F("<h3>pyMC Token</h3>"
+              "<form method='POST' action='/token'>"
+              "<label>New pyMC token</label>"
+              "<input type='password' name='token' autocomplete='new-password' maxlength='64'>"
+              "<label>Confirm pyMC token</label>"
+              "<input type='password' name='confirm' autocomplete='new-password' maxlength='64'>"
+              "<button type='submit'>Save pyMC token</button>"
+              "</form>");
     body += "<p class='m'>Current mode: <b>";
     body += cfg.tcpToken.length() > 0 ? "protected" : "open";
     body += F("</b>. This token must match the <code>token</code> value in pyMC so pyMC can connect to the radio. Leave both fields blank to clear it. Reboot required.</p>"
@@ -226,6 +251,40 @@ static void handleHostnameSave() {
                     "<p><a href='/'>Back to OTA page</a></p>"
                     "</body></html>");
     httpServer->send(200, "text/html; charset=utf-8", body);
+    delay(500);
+    ESP.restart();
+}
+
+static void handleNetworkSave() {
+    if (!checkAuth()) return;
+
+    WifiManager::Config cfg = WifiManager::getConfig();
+    cfg.useStaticIP = httpServer->hasArg("static");
+    cfg.staticIP    = parseIPArg(httpServer->arg("ip"));
+    cfg.subnet      = parseIPArg(httpServer->arg("sn"));
+    cfg.gateway     = parseIPArg(httpServer->arg("gw"));
+    cfg.dns1        = parseIPArg(httpServer->arg("dns1"));
+    cfg.dns2        = parseIPArg(httpServer->arg("dns2"));
+
+    if (cfg.useStaticIP) {
+        if ((uint32_t)cfg.staticIP == 0 || (uint32_t)cfg.subnet == 0 || (uint32_t)cfg.gateway == 0) {
+            httpServer->send(400, "text/plain",
+                             "Static IP, subnet, and gateway are required when static mode is enabled.\n");
+            return;
+        }
+    }
+
+    WifiManager::saveConfig(cfg);
+
+    Serial.printf("[OTA] network config updated by %s -> %s\n",
+                  httpServer->client().remoteIP().toString().c_str(),
+                  cfg.useStaticIP ? "static" : "dhcp");
+
+    sendSimplePage(F("Network saved"),
+                   F("Network saved"),
+                   cfg.useStaticIP
+                       ? F("The modem will reboot now and come back using the configured static network settings.")
+                       : F("The modem will reboot now and come back using DHCP."));
     delay(500);
     ESP.restart();
 }
@@ -375,6 +434,7 @@ void begin(const String& hn, const String& tk) {
     httpServer = new WebServer(HTTP_PORT);
     httpServer->on("/",       HTTP_GET,  handleRoot);
     httpServer->on("/hostname", HTTP_POST, handleHostnameSave);
+    httpServer->on("/network", HTTP_POST, handleNetworkSave);
     httpServer->on("/token",  HTTP_POST, handleTokenSave);
     httpServer->on("/auth",   HTTP_POST, handleAuthSave);
     httpServer->on("/update", HTTP_POST, handleUpdateResult, handleUpdateUpload);

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -176,17 +176,17 @@ static void handleRoot() {
             "</form>"
             "<p class='m'>Blank resets to the board default. Reboot required.</p>"
             "<hr>"
-            "<h3>pyMC TCP password</h3>"
+            "<h3>pyMC Token</h3>"
             "<form method='POST' action='/token'>"
-            "<label>New TCP password</label>"
+            "<label>New pyMC token</label>"
             "<input type='password' name='token' autocomplete='new-password' maxlength='64'>"
-            "<label>Confirm TCP password</label>"
+            "<label>Confirm pyMC token</label>"
             "<input type='password' name='confirm' autocomplete='new-password' maxlength='64'>"
-            "<button type='submit'>Save TCP password</button>"
+            "<button type='submit'>Save pyMC token</button>"
             "</form>";
     body += "<p class='m'>Current mode: <b>";
     body += cfg.tcpToken.length() > 0 ? "protected" : "open";
-    body += F("</b>. Leave both fields blank to clear the TCP password. Reboot required.</p>"
+    body += F("</b>. This token must match the <code>token</code> value in pyMC so pyMC can connect to the radio. Leave both fields blank to clear it. Reboot required.</p>"
               "<hr>"
             "<h3>HTTP password</h3>"
             "<form method='POST' action='/auth'>"
@@ -238,26 +238,26 @@ static void handleTokenSave() {
     String confirm   = httpServer->arg("confirm");
 
     if (requested.length() > MAX_TCP_TOKEN_LEN) {
-        httpServer->send(400, "text/plain", "TCP password must be 0-64 characters.\n");
+        httpServer->send(400, "text/plain", "pyMC token must be 0-64 characters.\n");
         return;
     }
     if (requested != confirm) {
-        httpServer->send(400, "text/plain", "TCP password confirmation does not match.\n");
+        httpServer->send(400, "text/plain", "pyMC token confirmation does not match.\n");
         return;
     }
 
     cfg.tcpToken = requested;
     WifiManager::saveConfig(cfg);
 
-    Serial.printf("[OTA] TCP password updated by %s -> %s\n",
+    Serial.printf("[OTA] pyMC token updated by %s -> %s\n",
                   httpServer->client().remoteIP().toString().c_str(),
                   requested.length() > 0 ? "set" : "cleared");
 
-    sendSimplePage(F("TCP password saved"),
-                   F("TCP password saved"),
+    sendSimplePage(F("pyMC token saved"),
+                   F("pyMC token saved"),
                    requested.length() > 0
-                       ? F("The modem will reboot now and require the new pyMC TCP password.")
-                       : F("The modem will reboot now and allow open TCP access again."));
+                       ? F("The modem will reboot now and require the new pyMC token.")
+                       : F("The modem will reboot now and allow open pyMC access again."));
     delay(500);
     ESP.restart();
 }

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -4,6 +4,7 @@
 #include "wifi_manager.h"
 #include "config_portal.h"
 #include "board_config.h"
+#include "compat.h"
 
 #include <WiFi.h>
 #include <Preferences.h>
@@ -14,11 +15,13 @@ static constexpr const char* NVS_NAMESPACE         = "lora_modem";
 static constexpr uint16_t    DEFAULT_TCP_PORT      = 5055;
 static constexpr uint32_t    STA_CONNECT_TIMEOUT_MS = 30000;
 static constexpr uint32_t    PRG_RESET_HOLD_MS     = 3000;
+static constexpr uint8_t     MAX_HOSTNAME_LEN      = 32;
 
 static Config  cfg;
 static Mode    currentMode = Mode::OFFLINE;
 static String  apSSID;
 static String  ipStr       = "---";
+static String  effectiveHostname;
 static bool    eventsRegistered = false;
 
 // Log lines use plain ASCII so any connected host protocol parser
@@ -61,11 +64,14 @@ static void loadConfig() {
     Preferences p;
     if (!p.begin(NVS_NAMESPACE, true)) {
         cfg = {};
+        cfg.hostname = "";
         cfg.tcpPort = DEFAULT_TCP_PORT;
+        effectiveHostname = "";
         return;
     }
     cfg.ssid        = p.getString("ssid",  "");
     cfg.password    = p.getString("pass",  "");
+    cfg.hostname    = p.getString("host",  "");
     cfg.useStaticIP = p.getBool  ("static", false);
     cfg.staticIP    = IPAddress(p.getUInt("ip",  0));
     cfg.gateway     = IPAddress(p.getUInt("gw",  0));
@@ -76,11 +82,57 @@ static void loadConfig() {
     p.end();
 }
 
+static String buildDefaultHostname() {
+    uint8_t mac[6] = {0};
+    compatGetMac(mac);
+    char buf[40];
+    snprintf(buf, sizeof(buf), "%s-%02x%02x%02x",
+             BOARD.mdns_prefix, mac[3], mac[4], mac[5]);
+    return String(buf);
+}
+
+static String sanitizeHostname(const String& raw) {
+    String out;
+    out.reserve(raw.length());
+
+    bool lastWasHyphen = false;
+    for (size_t i = 0; i < raw.length() && out.length() < MAX_HOSTNAME_LEN; i++) {
+        char c = raw[i];
+        if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
+
+        bool valid = (c >= 'a' && c <= 'z') ||
+                     (c >= '0' && c <= '9') ||
+                     c == '-';
+        if (!valid) c = '-';
+
+        if (c == '-') {
+            if (out.length() == 0 || lastWasHyphen) continue;
+            lastWasHyphen = true;
+        } else {
+            lastWasHyphen = false;
+        }
+        out += c;
+    }
+
+    while (out.endsWith("-")) {
+        out.remove(out.length() - 1);
+    }
+    return out;
+}
+
+static void refreshEffectiveHostname() {
+    effectiveHostname = sanitizeHostname(cfg.hostname);
+    if (effectiveHostname.length() == 0) {
+        effectiveHostname = buildDefaultHostname();
+    }
+}
+
 void saveConfig(const Config& newCfg) {
     Preferences p;
     if (!p.begin(NVS_NAMESPACE, false)) return;
     p.putString("ssid",  newCfg.ssid);
     p.putString("pass",  newCfg.password);
+    p.putString("host",  sanitizeHostname(newCfg.hostname));
     p.putBool  ("static", newCfg.useStaticIP);
     p.putUInt  ("ip",    (uint32_t)newCfg.staticIP);
     p.putUInt  ("gw",    (uint32_t)newCfg.gateway);
@@ -90,6 +142,8 @@ void saveConfig(const Config& newCfg) {
     p.putUShort("port",  newCfg.tcpPort);
     p.end();
     cfg = newCfg;
+    cfg.hostname = sanitizeHostname(cfg.hostname);
+    refreshEffectiveHostname();
 }
 
 void factoryReset() {
@@ -139,8 +193,9 @@ static void startAPMode() {
 static bool attemptSTA() {
     if (cfg.ssid.length() == 0) return false;
 
-    Serial.printf("[WiFi] STA connecting to '%s' (%s, port=%u, auth=%s)\n",
+    Serial.printf("[WiFi] STA connecting to '%s' host='%s' (%s, port=%u, auth=%s)\n",
                   cfg.ssid.c_str(),
+                  effectiveHostname.c_str(),
                   cfg.useStaticIP ? "static IP" : "DHCP",
                   (unsigned)cfg.tcpPort,
                   cfg.tcpToken.length() > 0 ? "token" : "open");
@@ -148,6 +203,7 @@ static bool attemptSTA() {
     WiFi.persistent(false);   // we manage persistence via Preferences
     WiFi.setAutoReconnect(true);
     WiFi.mode(WIFI_STA);
+    WiFi.setHostname(effectiveHostname.c_str());
     if (cfg.useStaticIP) {
         WiFi.config(cfg.staticIP, cfg.gateway, cfg.subnet, cfg.dns);
     }
@@ -184,13 +240,18 @@ void loadConfigOnly() {
     // Used on Wi-Fi-disabled boards so the saved tcpPort/tcpToken
     // are still available to the TCP server.
     loadConfig();
+    cfg.hostname = sanitizeHostname(cfg.hostname);
+    refreshEffectiveHostname();
 }
 
 void begin() {
     loadConfig();
+    cfg.hostname = sanitizeHostname(cfg.hostname);
+    refreshEffectiveHostname();
 
-    Serial.printf("[Boot] WifiManager: saved ssid='%s' %s\n",
+    Serial.printf("[Boot] WifiManager: saved ssid='%s' host='%s' %s\n",
                   cfg.ssid.c_str(),
+                  effectiveHostname.c_str(),
                   cfg.ssid.length() == 0 ? "(empty -> AP mode)" : "");
 
     if (!eventsRegistered) {
@@ -243,6 +304,7 @@ bool        isSTAConnected()  { return currentMode == Mode::STA_CONNECTED; }
 bool        isAPActive()      { return currentMode == Mode::AP_CONFIG; }
 const char* getIPString()     { return ipStr.c_str(); }
 const Config& getConfig()     { return cfg; }
+const char* getHostname()     { return effectiveHostname.c_str(); }
 
 const char* getSSID() {
     if (currentMode == Mode::AP_CONFIG) return apSSID.c_str();

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -76,7 +76,8 @@ static void loadConfig() {
     cfg.staticIP    = IPAddress(p.getUInt("ip",  0));
     cfg.gateway     = IPAddress(p.getUInt("gw",  0));
     cfg.subnet      = IPAddress(p.getUInt("sn",  0));
-    cfg.dns         = IPAddress(p.getUInt("dns", 0));
+    cfg.dns1        = IPAddress(p.getUInt("dns", 0));
+    cfg.dns2        = IPAddress(p.getUInt("dns2", 0));
     cfg.tcpToken    = p.getString("token", "");
     cfg.tcpPort     = p.getUShort("port", DEFAULT_TCP_PORT);
     p.end();
@@ -137,7 +138,8 @@ void saveConfig(const Config& newCfg) {
     p.putUInt  ("ip",    (uint32_t)newCfg.staticIP);
     p.putUInt  ("gw",    (uint32_t)newCfg.gateway);
     p.putUInt  ("sn",    (uint32_t)newCfg.subnet);
-    p.putUInt  ("dns",   (uint32_t)newCfg.dns);
+    p.putUInt  ("dns",   (uint32_t)newCfg.dns1);
+    p.putUInt  ("dns2",  (uint32_t)newCfg.dns2);
     p.putString("token", newCfg.tcpToken);
     p.putUShort("port",  newCfg.tcpPort);
     p.end();
@@ -205,7 +207,7 @@ static bool attemptSTA() {
     WiFi.mode(WIFI_STA);
     WiFi.setHostname(effectiveHostname.c_str());
     if (cfg.useStaticIP) {
-        WiFi.config(cfg.staticIP, cfg.gateway, cfg.subnet, cfg.dns);
+        WiFi.config(cfg.staticIP, cfg.gateway, cfg.subnet, cfg.dns1, cfg.dns2);
     }
     WiFi.begin(cfg.ssid.c_str(), cfg.password.c_str());
     currentMode = Mode::STA_CONNECTING;

--- a/pymc_driver/usb_radio.py
+++ b/pymc_driver/usb_radio.py
@@ -503,6 +503,7 @@ class USBLoRaRadio(_RadioBase):
         password: str,
         tcp_port: int = 5055,
         tcp_token: str = "",
+        hostname: Optional[str] = None,
     ) -> Optional[dict]:
         """Provision Wi-Fi credentials over USB and reboot into STA mode.
 
@@ -513,30 +514,39 @@ class USBLoRaRadio(_RadioBase):
         `get_wifi_status()` that STA came up.
 
         tcp_token: shared secret. Empty = open LAN (TCP + HTTP OTA). Non-empty
-        enforces CMD_AUTH on TCP and Basic-auth (user='heltec') on HTTP /update.
+        enforces CMD_AUTH on TCP and Basic-auth (user='admin') on HTTP /update.
+        hostname: optional mDNS/OTA hostname override. Omit it to preserve the
+        current hostname on older/newer firmware. Pass "" to reset to the
+        MAC-derived default on firmware that supports hostname provisioning.
 
         Returns the pending WIFI_STATUS dict, or None on timeout/error.
         """
         ssid_b = ssid.encode("utf-8")
         pass_b = password.encode("utf-8")
-        tok_b = tcp_token.encode("utf-8")
+<<<<<<< HEAD
+        tok_b  = tcp_token.encode("utf-8")
+        host_b = None if hostname is None else hostname.encode("utf-8")
         if len(ssid_b) == 0 or len(ssid_b) > 32:
             raise ValueError("SSID must be 1..32 bytes")
         if len(pass_b) > 64:
             raise ValueError("password must be <=64 bytes")
         if len(tok_b) > 64:
             raise ValueError("token must be <=64 bytes")
+        if host_b is not None and len(host_b) > 32:
+            raise ValueError("hostname must be <=32 bytes")
         if not (1 <= tcp_port <= 65535):
             raise ValueError("tcp_port out of range")
 
-        payload = (
+        payload = bytearray(
             bytes([len(ssid_b)]) + ssid_b +
             bytes([len(pass_b)]) + pass_b +
             struct.pack("<H", tcp_port) +
             bytes([len(tok_b)]) + tok_b
         )
+        if host_b is not None:
+            payload.extend(bytes([len(host_b)]) + host_b)
         resp = await self._send_command(
-            CMD_SET_WIFI, payload, expect_cmd=CMD_WIFI_STATUS, timeout=3.0
+            CMD_SET_WIFI, bytes(payload), expect_cmd=CMD_WIFI_STATUS, timeout=3.0
         )
         if resp is None:
             return None


### PR DESCRIPTION
## Summary

This PR expands the existing ESP32 OTA HTTP interface into a usable authenticated web management surface.

It adds:

* HTTP Basic Auth protection for the OTA web page
* Persistent configurable hostname support
* A web UI for hostname, network, pyMC token, HTTP password, and reboot
* DHCP/static IP configuration with live lease values shown in the UI
* A stats page for runtime/radio/network status
* An authenticated JSON API for automation and monitoring

This branch is based on `itk80/pymc_usb` `main` .

---

## Why

The existing OTA support worked, but it was minimal:

* OTA page access was not protected
* There was no easy way to manage hostname or network settings directly from the device
* There was no machine-friendly API for monitoring or remote configuration
* Ethernet hostname/static IP behavior did not align well with the new UI requirements

This PR turns the OTA page into a lightweight device-management surface without changing the core modem protocol.

---

## What Changed

### 1. Protect OTA Web UI with HTTP Auth

Added HTTP Basic Auth to both the web UI and OTA upload path.

Includes:

* Credential storage
* Password change flow in the UI
* Authenticated OTA upload support

---

### 2. Add Persistent Hostname Support

Added a saved hostname field and UI.

Behavior:

* Blank hostname falls back to the default MAC-derived hostname
* Configured hostname is used for mDNS and OTA naming
* Ethernet hostname handling was updated so the configured hostname is applied correctly during DHCP advertisement

---

### 3. Add pyMC Token Management UI

Added a dedicated pyMC Token section to the UI.

The UI now explicitly explains that this token must match the pyMC repeater token for TCP access to the modem.

---

### 4. Add Network Configuration UI

Added support for:

* DHCP (default)
* Optional static IP
* Subnet
* Gateway
* DNS 1
* DNS 2

The UI also shows live network lease values so users can see the active runtime configuration rather than only saved settings.

---

### 5. Add Reboot Action

Added a reboot button to the web UI for restarting the modem without changing configuration.

---

### 6. Add Stats Page

Added `/stats`, a runtime status page exposing:

* Firmware version
* Hostname
* IP/interface
* Connected pyMC client IP
* Uptime
* Live radio configuration
* RX/TX/error counters
* RSSI/SNR/noise floor
* Die temperature
* Network mode/details

---

### 7. Add JSON API

Added authenticated JSON endpoints and documented them in `API.md`.

Endpoints:

* `GET /api/temp`
* `GET /api/system`
* `GET /api/radio`
* `GET /api/network`
* `GET /api/stats`
* `GET /api/config`
* `POST /api/config`
* `POST /api/reboot`

These use the same HTTP Basic Auth as the web UI.

---

### 8. Add Runtime Stats Plumbing

Added a runtime snapshot layer so the UI and JSON API can expose live modem/radio state without duplicating logic.

---

### 9. Add JSON Dependency

Added `ArduinoJson` to support the config API.

---

## Files of Interest

### Main Implementation

* `firmware/src/ota_manager.cpp`
* `firmware/src/wifi_manager.cpp`
* `firmware/src/ethernet_manager.cpp`
* `firmware/src/main.cpp`

### Headers / Config

* `firmware/include/runtime_stats.h`
* `firmware/include/wifi_manager.h`
* `firmware/include/ethernet_manager.h`
* `firmware/include/ota_manager.h`
* `firmware/platformio.ini`

### Driver / Docs

* `pymc_driver/usb_radio.py`
* `API.md`
* `INSTALL.md`

---

## Testing

Successfully built with PlatformIO for:

* `heltec_v3`
* `esp32_p4_nano`

Also validated on real hardware for:

* Authenticated OTA uploads
* Hostname changes
* pyMC token changes
* Static IP save/apply behavior
* Stats page rendering
* JSON API responses

---

## Notes / Caveats

* `GET /api/config` intentionally returns the saved `tcp_token` in plaintext for remote-management symmetry

  * Protected by the same HTTP auth as the rest of the web UI

  * Firmware-side Ethernet hostname handling has been updated
* `TCPServer::available()` still emits the existing deprecation warning during build

  * This PR does not change that behavior

---

## Commit Range

This branch includes:

* `a296506` — firmware: require auth for OTA web page
* `6998702` — firmware: persist configurable node hostname
* `571bdbf` — ota: add hostname form to web UI
* `596e1fd` — ethernet: advertise configured DHCP hostname
* `189150e` — ota: add web UI for TCP password
* `141a7c0` — ota: rename TCP password UI to pyMC token
* `b57683a` — network: add static IP settings to web UI
* `fa41a8a` — ota: add stats page and JSON API


<img width="3840" height="3838" alt="image" src="https://github.com/user-attachments/assets/b3a426ce-f272-4a9c-b845-8945d3804dad" />
<img width="3840" height="3464" alt="image" src="https://github.com/user-attachments/assets/86eb698d-84a7-433f-8d52-7d751cec6d01" />
