### PR TITLE
firmware: count TCP parser CRC errors in modem status

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1109,6 +1109,10 @@ static void onSerialFrameErr(uint8_t err_code, TransportSource src) {
     sendError(err_code, src);
 }
 
+void noteTransportFrameError(uint8_t err_code) {
+    if (err_code == ERR_CRC_MISMATCH) status.crc_errors++;
+}
+
 // ─── Setup ───────────────────────────────────────────────────
 void setup() {
     // PRG held ≥3s at boot → wipe Wi-Fi NVS and reboot. Must come before

--- a/firmware/src/tcp_server.cpp
+++ b/firmware/src/tcp_server.cpp
@@ -12,6 +12,7 @@
 // Forward decl — implemented in main.cpp; invoked for authorized frames.
 extern void processHostCommand(uint8_t cmd, const uint8_t* payload,
                                uint16_t len, TransportSource src);
+extern void noteTransportFrameError(uint8_t err_code);
 
 namespace TCPServer {
 
@@ -94,6 +95,7 @@ static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len, Transpo
 
 static void onFrameErr(uint8_t err_code, TransportSource src) {
     (void)src;
+    noteTransportFrameError(err_code);
     sendErrorToClient(err_code);
 }
 


### PR DESCRIPTION
## Summary

This PR fixes CRC error accounting for TCP-connected `pymc_usb` modems.

The firmware already increments `crc_errors` for:

* LoRa packet CRC failures
* USB/serial host-frame CRC mismatches

However, the TCP parser path did not increment the same counter when rejecting malformed host frames with `ERR_CRC_MISMATCH`.

This change makes TCP parser CRC handling consistent with existing USB behavior, so modem `crc_errors` now reflects bad protocol frames received over TCP as well.

---

## Problem

`StatusResp.crc_errors` is exposed by the modem and used for diagnostics.

Before this change:

* Serial/USB parser CRC mismatches incremented `crc_errors`
* TCP parser CRC mismatches only returned `CMD_ERROR`
* The shared status counter did not increment

This caused TCP-connected modems to underreport CRC errors compared to USB-connected modems, even though malformed frames were still being rejected correctly.

---

## What Changed

When the TCP server frame parser reports an error:

* The TCP path now calls a shared counter hook
* `ERR_CRC_MISMATCH` increments the same global modem `crc_errors` counter used elsewhere
* The protocol error response behavior remains unchanged

### Files Changed

* `firmware/src/main.cpp`
* `firmware/src/tcp_server.cpp`

---

## Implementation Notes

Added a small shared helper in `main.cpp`:

* `noteTransportFrameError(uint8_t err_code)`

The existing serial callback already increments the counter on `ERR_CRC_MISMATCH`.

The TCP server now invokes the same helper from its `onFrameErr(...)` callback before returning the protocol error to the client.

This keeps CRC accounting aligned across transports without changing the wire protocol.

---

## Behavior After This PR

Malformed TCP modem frames with an invalid protocol CRC will now:

* Be rejected as before
* Return the existing error response
* Increment modem `crc_errors`
* Appear in `CMD_STATUS_RESP`
* Appear in modem diagnostics surfaces such as stats/API endpoints

---

## Why This Matters

Without this change, TCP-connected deployments could miss an entire class of transport/protocol errors in modem diagnostics.

After this PR, `crc_errors` becomes transport-consistent across:

* LoRa RX CRC failures
* USB parser CRC failures
* TCP parser CRC failures

---

## Testing

Validated by:

* Successfully building firmware for:

  * `ethermesh_1w`
* OTA flashing a live test node
* Sending deliberately malformed TCP frames with invalid protocol CRC values to port `5055`
* Confirming modem `crc_errors` increased accordingly

### Example Result

* Before test:

  * `crc_errors = 0`
* After sending 10 malformed TCP frames:

  * `crc_errors = 10`

---

## Scope

This PR is intentionally narrow:

* No driver changes
* No repeater changes
* No protocol format changes
* No UI/API changes

It only fixes firmware-side CRC accounting for TCP parser failures.
