### PR TITLE
firmware: add Heltec Wireless Tracker V2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ Ethernet) wired LAN.
 | Board                                                                                                       | MCU                          | Front end                  | Networks |
 |-------------------------------------------------------------------------------------------------------------|------------------------------|----------------------------|----------|
 | **Heltec WiFi LoRa 32 V3**                                                                                  | ESP32-S3                     | bare SX1262                | Wi-Fi    |
+| **Heltec WiFi LoRa 32 V4**                                                                                  | ESP32-S3                     | SX1262 + PA/LNA FEM        | Wi-Fi    |
+| **Heltec Wireless Tracker V2**                                                                              | ESP32-S3                     | SX1262 + KCT8103L PA/FEM + TFT 160×80 | Wi-Fi |
 | **Ikoka Stick** ([ndoo/ikoka-stick-meshtastic-device](https://github.com/ndoo/ikoka-stick-meshtastic-device))| XIAO ESP32-S3                | Ebyte E22-P868M30S, +30 dBm | Wi-Fi   |
 | **Seeed XIAO Wio-SX1262**                                                                                   | XIAO ESP32-S3                | bare SX1262                | Wi-Fi    |
 | **LilyGO T-LoRa T3-S3** v1.2/v1.3                                                                           | ESP32-S3                     | bare SX1262 + OLED         | Wi-Fi    |
 | **RAK3112 WisMesh**                                                                                         | ESP32-S3 (module)            | SX1262 in-module           | Wi-Fi    |
 | **WaveShare ESP32-P4-Nano**                                                                                 | ESP32-P4 (RISC-V) + ESP32-C6 | E22 (off-board, optional)  | **Ethernet *or* Wi-Fi** — runtime auto-select: cable plugged → Ethernet wins, no link → fall back to Wi-Fi via C6 SDIO bridge. Both at once is unstable with the radio attached, see [P4-Nano notes](#porting-to-another-esp32-p4-board) |
 | **Heltec T114**                                                                                             | nRF52840                     | bare SX1262 + TFT 135×240  | **none** — USB-CDC + UART only |
+| **Seeed XIAO nRF52840 + Wio-SX1262**                                                                        | XIAO nRF52840                | bare SX1262                | **none** — USB-CDC only |
 
 Drop-in replacement for `SX1262Radio` in pymc_core — all MeshCore logic
 (routing, encryption, retransmission) runs on the RPi. The modem handles
@@ -47,7 +50,7 @@ Raspberry Pi                                  pymc_modem modem
 
 ## Project layout
 
-- **`firmware/`** — PlatformIO tree, seven envs sharing one source.
+- **`firmware/`** — PlatformIO tree, ten envs sharing one source.
   Each board lives in `include/boards/<env>.h`; `platformio.ini` picks
   one via `-DBOARD_<NAME>`. Prebuilt artifacts (ESP32: `bootloader.bin
   / partitions.bin / firmware.bin`; nRF52 T114: `firmware.hex` +
@@ -94,6 +97,7 @@ Per-board highlights (full pin numbers in the headers, mDNS prefix is
 
 - **Heltec V3** — onboard SSD1306, bare SX1262, max 22 dBm.
 - **Heltec V4** — onboard SSD1306, SX1262 + V4.x PA/LNA front-end, native USB-CDC, max 22 dBm SX1262 command power.
+- **Heltec Wireless Tracker V2** — ESP32-S3 + SX1262 + KCT8103L PA/FEM, ST7735 TFT 160×80, native USB-CDC, max 22 dBm SX1262 command power.
 - **Ikoka Stick** — XIAO ESP32-S3 + E22-P868M30S, EN-held + DIO2-as-RF-switch, max 30 dBm chip / +10 dB PA, external OLED.
 - **XIAO Wio-SX1262** — Seeed XIAO ESP32-S3 + bare SX1262, no OLED.
 - **LilyGO T3-S3** — bare SX1262 + onboard SSD1306, native USB-CDC.

--- a/firmware/boards/heltec_tracker_v2.json
+++ b/firmware/boards/heltec_tracker_v2.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino": {
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_HELTEC_TRACKER_V2",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": ["wifi", "bluetooth", "lora"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "Heltec Wireless Tracker V2",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 921600,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://heltec.org/project/wireless-tracker-v2/",
+  "vendor": "Heltec"
+}

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -100,6 +100,17 @@ struct BoardConfig {
     // this at -1 so the firmware skips the dance.
     int8_t pin_vext_enable_low;
 
+    // Optional SPI TFT. Boards without one leave these pins at -1.
+    int8_t pin_tft_sda = -1;
+    int8_t pin_tft_scl = -1;
+    int8_t pin_tft_dc = -1;
+    int8_t pin_tft_rst = -1;
+    int8_t pin_tft_cs = -1;
+    int8_t pin_tft_bl = -1;
+    bool   tft_bl_active_high = true;
+    int8_t pin_tft_power = -1;
+    bool   tft_power_active_high = true;
+
     // PRG / user button. active_low = pressed pulls LOW.
     int8_t pin_user_button;
     bool   user_button_active_low;

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -205,10 +205,12 @@ extern const BoardConfig BOARD;
 #  include "boards/esp32_p4_nano.h"
 #elif defined(BOARD_HELTEC_T114)
 #  include "boards/heltec_t114.h"
+#elif defined(BOARD_HELTEC_TRACKER_V2)
+#  include "boards/heltec_tracker_v2.h"
 #elif defined(BOARD_XIAO_WIO_SX1262)
 #  include "boards/xiao_wio_sx1262.h"
 #elif defined(BOARD_XIAO_NRF52_WIO)
 #  include "boards/xiao_nrf52_wio.h"
 #else
-#  error "No board selected — add one of -DBOARD_HELTEC_V3 / -DBOARD_HELTEC_V4 / -DBOARD_IKOKA_STICK / -DBOARD_LILYGO_T3S3 / -DBOARD_RAK3112_WISMESH / -DBOARD_ESP32_P4_NANO / -DBOARD_HELTEC_T114 / -DBOARD_XIAO_WIO_SX1262 / -DBOARD_XIAO_NRF52_WIO to platformio.ini build_flags"
+#  error "No board selected — add one of -DBOARD_HELTEC_V3 / -DBOARD_HELTEC_V4 / -DBOARD_IKOKA_STICK / -DBOARD_LILYGO_T3S3 / -DBOARD_RAK3112_WISMESH / -DBOARD_ESP32_P4_NANO / -DBOARD_HELTEC_T114 / -DBOARD_HELTEC_TRACKER_V2 / -DBOARD_XIAO_WIO_SX1262 / -DBOARD_XIAO_NRF52_WIO to platformio.ini build_flags"
 #endif

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -85,6 +85,10 @@ struct BoardConfig {
 
     RfSwitchPolicy rf_switch;
 
+    // Optional LoRa TX activity LED. Boards without one leave pin at -1.
+    int8_t pin_lora_tx_led = -1;
+    bool   lora_tx_led_active_high = true;
+
     // I2C bus for the SSD1306 OLED (same driver across all boards).
     int8_t pin_i2c_sda;
     int8_t pin_i2c_scl;
@@ -112,6 +116,11 @@ struct BoardConfig {
     // 32 MHz TCXO powered by SX1262 DIO3 at 1.8 V.
     bool  use_dio3_tcxo;
     float tcxo_voltage;
+
+    // Optional SX126x board-level tuning applied after radio.begin().
+    int16_t sx126x_current_limit_ma = -1;
+    bool    sx126x_rx_boosted_gain = false;
+    bool    sx126x_register_patch = false;
 
     // Some carriers (ESP32-P4-Nano) ship without an SX1262 — the
     // module is added later. When false, main.cpp / wifi_manager skip

--- a/firmware/include/boards/heltec_t114.h
+++ b/firmware/include/boards/heltec_t114.h
@@ -63,12 +63,25 @@ inline const BoardConfig BOARD = {
 
     {-1, 0, -1, -1, true},  // SX1262 internal switch via DIO2
 
+    -1,    // pin_lora_tx_led
+    true,  // lora_tx_led_active_high
+
     // No I2C OLED on this board (TFT-LCD is on a separate SPI bus
     // and isn't wired up in iter 1 firmware).
     -1,  // pin_i2c_sda
     -1,  // pin_i2c_scl
     -1,  // pin_i2c_oled_rst
     -1,  // pin_vext_enable_low
+
+    -1,    // pin_tft_sda — T114 TFT uses dedicated constants in tft_display.cpp
+    -1,    // pin_tft_scl
+    -1,    // pin_tft_dc
+    -1,    // pin_tft_rst
+    -1,    // pin_tft_cs
+    -1,    // pin_tft_bl
+    true,  // tft_bl_active_high
+    -1,    // pin_tft_power
+    true,  // tft_power_active_high
 
     42,    // pin_user_button
     true,  // user_button_active_low
@@ -79,6 +92,10 @@ inline const BoardConfig BOARD = {
 
     true,  // use_dio3_tcxo
     1.8f,  // tcxo_voltage
+
+    -1,     // sx126x_current_limit_ma
+    false,  // sx126x_rx_boosted_gain
+    false,  // sx126x_register_patch
 
     true,   // has_lora_radio
     false,  // has_wifi — nRF52 has BT but not Wi-Fi
@@ -92,4 +109,7 @@ inline const BoardConfig BOARD = {
 
     {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+
+    {{-1, false}, {-1, false}, {-1, false}, {-1, false}},
+    0,
 };

--- a/firmware/include/boards/heltec_tracker_v2.h
+++ b/firmware/include/boards/heltec_tracker_v2.h
@@ -28,12 +28,22 @@ inline const BoardConfig BOARD = {
     .pin_lora_tx_led = 18,
     .lora_tx_led_active_high = true,
 
-    // Tracker V2 has a TFT/GPS VEXT rail, not the SSD1306 OLED used by this
-    // firmware. Leave display pins disabled; do not power GPS/display VEXT.
+    // Tracker V2 uses an ST7735 TFT on a dedicated write-only SPI bus.
+    // VEXT powers the display/GPS peripheral rail; this build only claims
+    // it while the display is on.
     .pin_i2c_sda      = -1,
     .pin_i2c_scl      = -1,
     .pin_i2c_oled_rst = -1,
     .pin_vext_enable_low = -1,
+    .pin_tft_sda = 42,
+    .pin_tft_scl = 41,
+    .pin_tft_dc  = 40,
+    .pin_tft_rst = 39,
+    .pin_tft_cs  = 38,
+    .pin_tft_bl  = 21,
+    .tft_bl_active_high = true,
+    .pin_tft_power = 3,
+    .tft_power_active_high = true,
 
     .pin_user_button        = 0,
     .user_button_active_low = true,

--- a/firmware/include/boards/heltec_tracker_v2.h
+++ b/firmware/include/boards/heltec_tracker_v2.h
@@ -1,0 +1,59 @@
+// =============================================================
+// boards/heltec_tracker_v2.h — Heltec Wireless Tracker V2
+// ESP32-S3 + SX1262 + KCT8103L PA/FEM, Wi-Fi/TCP modem build.
+// =============================================================
+#pragma once
+
+inline const BoardConfig BOARD = {
+    .name        = "Heltec Tracker V2",
+    .fw_suffix   = "heltec_tracker_v2",
+    .mdns_prefix = "heltec-tracker-v2",
+
+    .pin_lora_nss  = 8,
+    .pin_lora_rst  = 12,
+    .pin_lora_busy = 13,
+    .pin_lora_dio1 = 14,
+    .pin_lora_sck  = 9,
+    .pin_lora_miso = 11,
+    .pin_lora_mosi = 10,
+
+    .rf_switch = {
+        .en_pin            = -1,
+        .en_low_hold_ms    = 0,
+        .rx_pin            = -1,
+        .tx_pin            = -1,
+        .dio2_as_rf_switch = true,
+    },
+
+    // Tracker V2 has a TFT/GPS VEXT rail, not the SSD1306 OLED used by this
+    // firmware. Leave display pins disabled; do not power GPS/display VEXT.
+    .pin_i2c_sda      = -1,
+    .pin_i2c_scl      = -1,
+    .pin_i2c_oled_rst = -1,
+    .pin_vext_enable_low = -1,
+
+    .pin_user_button        = 0,
+    .user_button_active_low = true,
+
+    // MeshCore distinguishes the default LORA_TX_POWER=9 dBm from the board
+    // ceiling MAX_LORA_TX_POWER=22 dBm. This clamp is the SX1262 chip-side
+    // maximum; the KCT8103L PA/FEM path is estimated around 28 dBm at antenna.
+    .max_tx_power_dbm = 22,
+
+    .use_dio3_tcxo = true,
+    .tcxo_voltage  = 1.8f,
+
+    .has_lora_radio = true,
+    .has_wifi       = true,
+    .has_network    = true,
+    .pin_protocol_uart_rx = -1,
+    .pin_protocol_uart_tx = -1,
+    .protocol_uart_baud   = 921600,
+    .ethernet = { .enabled = false },
+    .static_gpios = {
+        { 7, true },  // P_LORA_PA_POWER / VFEM_Ctrl
+        { 4, true },  // P_LORA_KCT8103L_PA_CSD
+        { 5, true },  // P_LORA_KCT8103L_PA_CTX: LNA bypass, MeshCore default
+    },
+    .static_gpio_count = 3,
+};

--- a/firmware/include/boards/heltec_tracker_v2.h
+++ b/firmware/include/boards/heltec_tracker_v2.h
@@ -25,6 +25,9 @@ inline const BoardConfig BOARD = {
         .dio2_as_rf_switch = true,
     },
 
+    .pin_lora_tx_led = 18,
+    .lora_tx_led_active_high = true,
+
     // Tracker V2 has a TFT/GPS VEXT rail, not the SSD1306 OLED used by this
     // firmware. Leave display pins disabled; do not power GPS/display VEXT.
     .pin_i2c_sda      = -1,
@@ -42,6 +45,9 @@ inline const BoardConfig BOARD = {
 
     .use_dio3_tcxo = true,
     .tcxo_voltage  = 1.8f,
+    .sx126x_current_limit_ma = 140,
+    .sx126x_rx_boosted_gain = true,
+    .sx126x_register_patch = true,
 
     .has_lora_radio = true,
     .has_wifi       = true,

--- a/firmware/include/boards/xiao_nrf52_wio.h
+++ b/firmware/include/boards/xiao_nrf52_wio.h
@@ -59,12 +59,25 @@ inline const BoardConfig BOARD = {
 
     {-1, 0, 5, -1, true},  // RXEN on D5/P0.05; TX via DIO2
 
+    -1,    // pin_lora_tx_led
+    true,  // lora_tx_led_active_high
+
     // No I2C peripheral on this kit. D4/D5 are claimed by NSS/RXEN,
     // so the silkscreen "SDA/SCL" labels are not honoured here.
     -1,  // pin_i2c_sda
     -1,  // pin_i2c_scl
     -1,  // pin_i2c_oled_rst
     -1,  // pin_vext_enable_low
+
+    -1,    // pin_tft_sda
+    -1,    // pin_tft_scl
+    -1,    // pin_tft_dc
+    -1,    // pin_tft_rst
+    -1,    // pin_tft_cs
+    -1,    // pin_tft_bl
+    true,  // tft_bl_active_high
+    -1,    // pin_tft_power
+    true,  // tft_power_active_high
 
     18,    // pin_user_button = P0.18 (Adafruit BTN0 / DFU)
     true,  // user_button_active_low
@@ -75,6 +88,10 @@ inline const BoardConfig BOARD = {
 
     true,  // use_dio3_tcxo
     1.8f,  // tcxo_voltage — 32 MHz TCXO on Wio-SX1262
+
+    -1,     // sx126x_current_limit_ma
+    false,  // sx126x_rx_boosted_gain
+    false,  // sx126x_register_patch
 
     true,   // has_lora_radio
     false,  // has_wifi — nRF52 has BLE but not Wi-Fi
@@ -87,4 +104,7 @@ inline const BoardConfig BOARD = {
 
     {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+
+    {{-1, false}, {-1, false}, {-1, false}, {-1, false}},
+    0,
 };

--- a/firmware/include/tft_display.h
+++ b/firmware/include/tft_display.h
@@ -1,5 +1,5 @@
 // =============================================================
-// tft_display.h — ST7789 1.14" 135×240 driver for Heltec T114.
+// tft_display.h — SPI TFT display drivers for Heltec boards.
 //
 // Same public surface as `oled_display.h` (the SSD1306 driver
 // for ESP32 boards) so main.cpp's call sites compile unchanged
@@ -7,18 +7,9 @@
 // still called `OledDisplay` even though the underlying panel is
 // a TFT — keeps the name consistent across the firmware family.
 //
-// Hardware (T114 V2-specific, see Datasheet_T114.pdf and the
-// MeshCore variant in _incoming/MeshCore-main):
-//   * Panel: Heltec LH114T-IF03 — IPS, 135×240, 262 K colours,
-//            Sitronix ST7789V controller, 4-line SPI write-only.
-//   * SPI bus: shared with the SX1262 on the default SPI
-//              peripheral (SCK=P0.19, MOSI=P0.22, MISO=P0.23).
-//              CS gates which device gets the burst.
-//   * Control: CS = P0.11, DC/RS = P0.12, RST = P0.02.
-//   * Power gates: VDD_CTL = P0.03 (panel logic rail), LEDA_CTL
-//                  = P0.15 (backlight LED anode). Both must be
-//                  driven HIGH before any draw; pulled LOW in
-//                  turnOff() to save current.
+// Board-specific pin maps live either in BoardConfig (ESP32-S3
+// Tracker V2) or in the custom board variant/constants already used
+// by the nRF52 T114 driver.
 // =============================================================
 #pragma once
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -62,6 +62,23 @@ build_flags =
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DBOARD_HELTEC_V4
 
+[env:heltec_tracker_v2]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
+board = heltec_tracker_v2
+; Heltec Wireless Tracker V2 (ESP32-S3 + SX1262 + KCT8103L PA/FEM).
+; Local board JSON mirrors MeshCore's 8 MB ESP32-S3/QIO target, while
+; LoRa/FEM GPIOs live in boards/heltec_tracker_v2.h.
+;
+; MeshCore's board definition uses ARDUINO_USB_MODE=0 and CDC on boot for
+; the native USB path, so override the repo-wide USB_MODE=1 default here.
+build_unflags =
+    -DARDUINO_USB_MODE=1
+build_flags =
+    ${env.build_flags}
+    -DARDUINO_USB_MODE=0
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HELTEC_TRACKER_V2
+
 [env:ikoka_stick]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
 board = seeed_xiao_esp32s3

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -73,11 +73,18 @@ board = heltec_tracker_v2
 ; the native USB path, so override the repo-wide USB_MODE=1 default here.
 build_unflags =
     -DARDUINO_USB_MODE=1
+lib_deps =
+    ${env.lib_deps}
+    adafruit/Adafruit ST7735 and ST7789 Library@^1.10.0
+    adafruit/Adafruit BusIO@^1.16.0
 build_flags =
     ${env.build_flags}
     -DARDUINO_USB_MODE=0
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DBOARD_HELTEC_TRACKER_V2
+build_src_filter =
+    +<*>
+    -<oled_display.cpp>
 
 [env:ikoka_stick]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -206,7 +206,7 @@ upload_protocol = nrfutil
 ; Adafruit nRF52 BSP defaults to C++14; bump to C++17 so the
 ; `inline const BoardConfig BOARD = {...}` definition in the
 ; board header compiles without a warning.
-build_unflags = -std=gnu++14 -std=c++14
+build_unflags = -std=gnu++11 -std=c++11 -std=gnu++14 -std=c++14
 build_flags =
     -std=gnu++17
     -DCFG_DEBUG=0
@@ -259,7 +259,7 @@ upload_protocol = nrfutil
 ; Adafruit nRF52 BSP defaults to C++14; bump to C++17 so the
 ; `inline const BoardConfig BOARD = {...}` definition in the
 ; board header compiles without a warning.
-build_unflags = -std=gnu++14 -std=c++14
+build_unflags = -std=gnu++11 -std=c++11 -std=gnu++14 -std=c++14
 build_flags =
     -std=gnu++17
     -DCFG_DEBUG=0

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -140,9 +140,22 @@ static String fwVersion;   // populated in setup()
 static constexpr uint32_t LOOP_WDT_TIMEOUT_S = 30;
 
 // ─── Hardware setup ──────────────────────────────────────────
+class PymcSX1262 : public SX1262 {
+public:
+    using SX1262::SX1262;
+
+    int16_t applyRegisterPatch08B5() {
+        uint8_t value = 0;
+        int16_t state = readRegister(0x08B5, &value, 1);
+        if (state != RADIOLIB_ERR_NONE) return state;
+        value |= 0x01;
+        return writeRegister(0x08B5, &value, 1);
+    }
+};
+
 // SX1262 / E22-P pin map comes from BOARD (see boards/<name>.h).
-SX1262 radio = new Module(BOARD.pin_lora_nss, BOARD.pin_lora_dio1,
-                          BOARD.pin_lora_rst, BOARD.pin_lora_busy);
+PymcSX1262 radio = new Module(BOARD.pin_lora_nss, BOARD.pin_lora_dio1,
+                              BOARD.pin_lora_rst, BOARD.pin_lora_busy);
 
 // Single instance regardless of build — on ESP32 this is the real
 // SSD1306 driver from oled_display.cpp; on nRF52 it's a no-op stub
@@ -172,6 +185,7 @@ static bool autoCadEnabled = false;   // pre-TX CAD; enabled via CMD_SET_AUTO_CA
 // A single flag avoids the race where an IRQ that fires at the tail of a TX
 // could leak into the next RX handler or vice-versa.
 static volatile bool dio1Flag    = false;
+static volatile uint32_t dio1IrqCount = 0;
 static bool        radioReady    = false;
 static bool        isTxActive    = false;
 
@@ -292,6 +306,7 @@ IRAM_ATTR
 #endif
 void onDio1Rise() {
     dio1Flag = true;
+    dio1IrqCount = dio1IrqCount + 1;
 }
 
 // ─── E22 RF switch boot sequence ────────────────────────────
@@ -315,6 +330,22 @@ static void rfSwitchEnLowAtBoot() {
     enLowStartedMs = millis();
 }
 
+static void writeOutputPin(int8_t pin, bool high) {
+    if (pin < 0) return;
+    pinMode(pin, OUTPUT);
+    digitalWrite(pin, high ? HIGH : LOW);
+}
+
+static void setTxLed(bool on) {
+    if (BOARD.pin_lora_tx_led < 0) return;
+    bool high = on ? BOARD.lora_tx_led_active_high
+                   : !BOARD.lora_tx_led_active_high;
+    writeOutputPin(BOARD.pin_lora_tx_led, high);
+}
+
+static void txLedInitAtBoot() {
+    setTxLed(false);
+}
 static void rfSwitchEnHighAfterSettle() {
     if (!BOARD.has_lora_radio) return;
     if (BOARD.rf_switch.en_pin < 0) return;
@@ -355,7 +386,8 @@ static void rfSwitchConfigureRadio() {
     // only set dio2_as_rf_switch and leave rx_pin/tx_pin == -1, so the second
     // call becomes a no-op for them.
     if (BOARD.rf_switch.dio2_as_rf_switch) {
-        radio.setDio2AsRfSwitch(true);
+        int state = radio.setDio2AsRfSwitch(true);
+        Serial.printf("[INFO] setDio2AsRfSwitch(true) -> %d\n", state);
     }
     if (BOARD.rf_switch.rx_pin >= 0 || BOARD.rf_switch.tx_pin >= 0) {
         uint32_t rx = BOARD.rf_switch.rx_pin >= 0
@@ -365,6 +397,26 @@ static void rfSwitchConfigureRadio() {
                           ? (uint32_t)BOARD.rf_switch.tx_pin
                           : RADIOLIB_NC;
         radio.setRfSwitchPins(rx, tx);
+        Serial.printf("[INFO] setRfSwitchPins(rx=%lu tx=%lu)\n",
+                      (unsigned long)rx, (unsigned long)tx);
+    }
+}
+
+static void configureBoardRadioOptions() {
+    if (BOARD.sx126x_current_limit_ma > 0) {
+        int state = radio.setCurrentLimit(BOARD.sx126x_current_limit_ma);
+        Serial.printf("[INFO] setCurrentLimit(%d mA) -> %d\n",
+                      (int)BOARD.sx126x_current_limit_ma, state);
+    }
+
+    if (BOARD.sx126x_rx_boosted_gain) {
+        int state = radio.setRxBoostedGainMode(true);
+        Serial.printf("[INFO] setRxBoostedGainMode(true) -> %d\n", state);
+    }
+
+    if (BOARD.sx126x_register_patch) {
+        int state = radio.applyRegisterPatch08B5();
+        Serial.printf("[INFO] SX126x register patch 0x08B5 -> %d\n", state);
     }
 }
 
@@ -613,6 +665,7 @@ bool startReceive() {
     // which re-runs applyConfig() and then calls this function
     // again with radioStandby=false.
     if (radioStandby) return true;
+    rfSwitchFemSetReceive();
     return radio.startReceive() == RADIOLIB_ERR_NONE;
 }
 
@@ -747,6 +800,8 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
         }
 
         dio1Flag = false;
+        uint32_t irqStart = dio1IrqCount;
+        setTxLed(true);
         int state = radio.startTransmit((uint8_t*)payload, len);
         LOG_R_INFO("TX_REQUEST len=%u src=%u state=%d",
                    (unsigned)len, (unsigned)src, state);
@@ -754,6 +809,7 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
             LOG_R_ERR("startTransmit() failed, state=%d", state);
             isTxActive = false;
             radio.finishTransmit();
+            setTxLed(false);
             sendError(ERR_TX_TIMEOUT, src);
             startReceive();
             break;
@@ -775,6 +831,7 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
 
         bool txOk = dio1Flag;
         radio.finishTransmit();
+        setTxLed(false);
         dio1Flag = false;
         isTxActive = false;
         lastPacketTime = millis();
@@ -793,7 +850,8 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
         } else {
             // Hard TX timeout — the SX1262 is likely stuck in a bad state.
             // Rebuild from scratch: standby → re-apply full config → RX.
-            LOG_R_ERR("TX hard timeout (%u bytes) — resetting radio", (unsigned)len);
+            LOG_R_ERR("TX hard timeout (%u bytes, dio1_delta=%lu) — resetting radio",
+                      (unsigned)len, (unsigned long)(dio1IrqCount - irqStart));
             radio.standby();
             delay(5);
             applyConfig(currentConfig);
@@ -1166,6 +1224,7 @@ void setup() {
     // below makes sure the full board.en_low_hold_ms has elapsed
     // before SPI traffic begins.
     rfSwitchEnLowAtBoot();
+    txLedInitAtBoot();
 
 #if defined(BOARD_HELTEC_T114)
     // Restore non-volatile T114 state BEFORE radio init so we know
@@ -1282,7 +1341,13 @@ void setup() {
 #endif
         }
 
+        LOG_R_INFO("radio.begin nss=%d dio1=%d rst=%d busy=%d spi=(%d,%d,%d)",
+                   (int)BOARD.pin_lora_nss, (int)BOARD.pin_lora_dio1,
+                   (int)BOARD.pin_lora_rst, (int)BOARD.pin_lora_busy,
+                   (int)BOARD.pin_lora_sck, (int)BOARD.pin_lora_miso,
+                   (int)BOARD.pin_lora_mosi);
         int state = radio.begin();
+        LOG_R_INFO("radio.begin -> %d", state);
         if (state != RADIOLIB_ERR_NONE) {
             oled.showError("SX1262 init fail!");
             while (Serial.availableForWrite() == 0) delay(10);
@@ -1293,8 +1358,12 @@ void setup() {
             while (true) delay(1000);
         }
 
-        if (BOARD.use_dio3_tcxo) radio.setTCXO(BOARD.tcxo_voltage);
+        if (BOARD.use_dio3_tcxo) {
+            state = radio.setTCXO(BOARD.tcxo_voltage);
+            LOG_R_INFO("setTCXO(%.1f V) -> %d", BOARD.tcxo_voltage, state);
+        }
         rfSwitchConfigureRadio();
+        configureBoardRadioOptions();
 
         if (!applyConfig(currentConfig)) {
             oled.showError("Config fail!");
@@ -1303,6 +1372,7 @@ void setup() {
         }
 
         radio.setDio1Action(onDio1Rise);
+        LOG_R_INFO("DIO1 IRQ attached on GPIO%d", (int)BOARD.pin_lora_dio1);
 
         if (!startReceive()) {
             oled.showError("RX start fail!");

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -33,7 +33,11 @@
 #  include <esp_task_wdt.h>
 #  include <esp_system.h>
 #  include <esp_mac.h>
-#  include "oled_display.h"
+#  if defined(BOARD_HELTEC_TRACKER_V2)
+#    include "tft_display.h"
+#  else
+#    include "oled_display.h"
+#  endif
 #  include "wifi_manager.h"
 #  include "tcp_server.h"
 #  include "ota_manager.h"

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -669,7 +669,6 @@ bool startReceive() {
     // which re-runs applyConfig() and then calls this function
     // again with radioStandby=false.
     if (radioStandby) return true;
-    rfSwitchFemSetReceive();
     return radio.startReceive() == RADIOLIB_ERR_NONE;
 }
 

--- a/firmware/src/tft_display.cpp
+++ b/firmware/src/tft_display.cpp
@@ -1,11 +1,10 @@
 // =============================================================
-// tft_display.cpp — Heltec T114 ST7789 (LH114T-IF03) driver.
+// tft_display.cpp — Heltec SPI TFT display drivers.
 //
 // Compiled into every env (because src_filter `+<*>` picks it up)
-// but the contents are gated on -DBOARD_HELTEC_T114 so non-T114
-// builds skip it without needing per-env src_filter exclusions.
-// On T114 it replaces the SSD1306 oled_display.cpp (which the
-// heltec_t114 env excludes via build_src_filter).
+// but the contents are gated on board flags so non-TFT builds skip it
+// without needing per-env src_filter exclusions. TFT board envs exclude
+// oled_display.cpp and keep main.cpp talking to this same OledDisplay API.
 //
 // The TFT lives on the second hardware SPI peripheral (`SPI1` in
 // the Adafruit BSP — PIN_SPI1_SCK=P1.08, MOSI=P1.09, MISO=P1.11
@@ -18,7 +17,221 @@
 // Public API matches OledDisplay so main.cpp doesn't care which
 // panel lives on the board.
 // =============================================================
-#if defined(BOARD_HELTEC_T114)
+#if defined(BOARD_HELTEC_TRACKER_V2)
+
+#include "tft_display.h"
+#include "board_config.h"
+
+#include <Adafruit_GFX.h>
+#include <Adafruit_ST7735.h>
+
+static constexpr int16_t TFT_W = 160;
+static constexpr int16_t TFT_H = 80;
+static constexpr int16_t HEADER_H = 14;
+
+static constexpr uint16_t COLOUR_BG     = 0x0000;
+static constexpr uint16_t COLOUR_FG     = 0xFFFF;
+static constexpr uint16_t COLOUR_HEADER = 0x07E0;
+static constexpr uint16_t COLOUR_ACCENT = 0x07FF;
+static constexpr uint16_t COLOUR_WARN   = 0xFD20;
+static constexpr uint16_t COLOUR_ERR    = 0xF800;
+
+static Adafruit_ST7735 tft(BOARD.pin_tft_cs, BOARD.pin_tft_dc,
+                           BOARD.pin_tft_sda, BOARD.pin_tft_scl,
+                           BOARD.pin_tft_rst);
+
+static void writeActivePin(int8_t pin, bool activeHigh, bool active) {
+    if (pin < 0) return;
+    pinMode(pin, OUTPUT);
+    digitalWrite(pin, active == activeHigh ? HIGH : LOW);
+}
+
+static void drawHeader(const char* displayName, const char* version) {
+    tft.fillRect(0, 0, TFT_W, HEADER_H, COLOUR_HEADER);
+    tft.setTextSize(1);
+    tft.setTextColor(COLOUR_BG, COLOUR_HEADER);
+    tft.setCursor(2, 3);
+    const char* name = (displayName && *displayName) ? displayName : "pyMC";
+    tft.print(name);
+
+    if (version) {
+        int16_t bx, by; uint16_t bw, bh;
+        tft.getTextBounds(version, 0, 0, &bx, &by, &bw, &bh);
+        if (bw < 70) {
+            tft.setCursor(TFT_W - (int16_t)bw - 2, 3);
+            tft.print(version);
+        }
+    }
+
+    tft.setTextColor(COLOUR_FG, COLOUR_BG);
+}
+
+static void drawText(int16_t x, int16_t y, const char* text,
+                     uint16_t colour = COLOUR_FG, uint8_t size = 1) {
+    tft.setTextSize(size);
+    tft.setTextColor(colour, COLOUR_BG);
+    tft.setCursor(x, y);
+    tft.print(text ? text : "");
+}
+
+void OledDisplay::begin() {
+    if (BOARD.pin_tft_sda < 0 || BOARD.pin_tft_scl < 0 ||
+        BOARD.pin_tft_dc < 0 || BOARD.pin_tft_rst < 0 ||
+        BOARD.pin_tft_cs < 0) {
+        _ready = false;
+        return;
+    }
+
+    writeActivePin(BOARD.pin_tft_power, BOARD.tft_power_active_high, true);
+    writeActivePin(BOARD.pin_tft_bl, BOARD.tft_bl_active_high, true);
+    pinMode(BOARD.pin_tft_rst, OUTPUT);
+    digitalWrite(BOARD.pin_tft_rst, HIGH);
+    delay(10);
+
+    tft.initR(INITR_MINI160x80);
+    tft.setRotation(1);
+    uint8_t madctl = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST7735_MADCTL_BGR;
+    tft.sendCommand(ST77XX_MADCTL, &madctl, 1);
+    tft.setSPISpeed(40000000);
+    tft.fillScreen(COLOUR_BG);
+    tft.setTextColor(COLOUR_FG, COLOUR_BG);
+    tft.setTextWrap(false);
+    tft.cp437(true);
+    _ready = true;
+}
+
+void OledDisplay::setDisplayName(const char* name) {
+    if (!name) name = "";
+    snprintf(_displayName, sizeof(_displayName), "%s", name);
+}
+
+void OledDisplay::setRadioInfo(uint32_t freq_hz, uint8_t sf, uint32_t bw_hz,
+                               uint8_t cr, int8_t power_dbm,
+                               int16_t last_rssi, int16_t last_snr_x10) {
+    _freq_hz = freq_hz;
+    _sf = sf;
+    _bw_hz = bw_hz;
+    _cr = cr;
+    _power_dbm = power_dbm;
+    _last_rssi = last_rssi;
+    _last_snr_x10 = last_snr_x10;
+}
+
+void OledDisplay::setStandby(bool on) {
+    _standby = on;
+}
+
+void OledDisplay::showSplash() {
+    if (!_ready) return;
+    tft.fillScreen(COLOUR_BG);
+    drawText(8, 18, "pyMC", COLOUR_ACCENT, 3);
+    drawText(8, 50, BOARD.name, COLOUR_FG, 1);
+}
+
+void OledDisplay::showStatus(uint32_t rx, uint32_t tx,
+                             const char* ssid, const char* ip,
+                             const char* state, const char* version) {
+    if (!_ready) return;
+    tft.fillScreen(COLOUR_BG);
+    drawHeader(_displayName, version);
+
+    if (_standby) {
+        drawText(22, 28, "STANDBY", COLOUR_ERR, 2);
+        drawText(18, 52, "radio parked", COLOUR_FG, 1);
+        return;
+    }
+
+    char buf[48];
+    snprintf(buf, sizeof(buf), "%s  RX %lu TX %lu",
+             state ? state : "---", (unsigned long)rx, (unsigned long)tx);
+    drawText(2, 18, buf, COLOUR_ACCENT, 1);
+
+    if (_last_rssi == INT16_MIN) {
+        snprintf(buf, sizeof(buf), "RSSI --  SNR --");
+    } else {
+        snprintf(buf, sizeof(buf), "RSSI %d  SNR %.1f",
+                 (int)_last_rssi, _last_snr_x10 / 10.0);
+    }
+    drawText(2, 31, buf, COLOUR_FG, 1);
+
+    snprintf(buf, sizeof(buf), "%.3fM SF%u BW%lu",
+             _freq_hz / 1e6, (unsigned)_sf,
+             (unsigned long)(_bw_hz / 1000));
+    drawText(2, 44, buf, COLOUR_FG, 1);
+
+    snprintf(buf, sizeof(buf), "%s %s", ssid ? ssid : "---", ip ? ip : "---");
+    drawText(2, 57, buf, COLOUR_WARN, 1);
+}
+
+void OledDisplay::showRadioConfig(uint32_t freq_hz, uint32_t bandwidth_hz,
+                                  uint8_t sf, uint8_t cr, int8_t power_dbm,
+                                  uint16_t syncword, uint8_t preamble_len,
+                                  const char* version) {
+    if (!_ready) return;
+    tft.fillScreen(COLOUR_BG);
+    drawHeader(_displayName, version);
+
+    char buf[48];
+    snprintf(buf, sizeof(buf), "%.3f MHz", freq_hz / 1e6);
+    drawText(2, 18, buf, COLOUR_ACCENT, 1);
+    snprintf(buf, sizeof(buf), "BW %lu SF%u CR4/%u",
+             (unsigned long)bandwidth_hz, (unsigned)sf, (unsigned)cr);
+    drawText(2, 31, buf, COLOUR_FG, 1);
+    snprintf(buf, sizeof(buf), "Pwr %d dBm Sync %02X",
+             (int)power_dbm, (unsigned)syncword);
+    drawText(2, 44, buf, COLOUR_FG, 1);
+    snprintf(buf, sizeof(buf), "Preamble %u", (unsigned)preamble_len);
+    drawText(2, 57, buf, COLOUR_FG, 1);
+}
+
+void OledDisplay::showDiagnostics(uint32_t uptime_sec,
+                                  const char* tcp_client_ip,
+                                  uint32_t usb_idle_sec,
+                                  uint32_t rx_count, uint32_t tx_count,
+                                  uint32_t crc_errors,
+                                  const char* version) {
+    if (!_ready) return;
+    tft.fillScreen(COLOUR_BG);
+    drawHeader(_displayName, version);
+
+    char buf[48];
+    uint32_t h = uptime_sec / 3600;
+    uint32_t m = (uptime_sec / 60) % 60;
+    uint32_t s = uptime_sec % 60;
+    snprintf(buf, sizeof(buf), "Up %lu:%02lu:%02lu",
+             (unsigned long)h, (unsigned long)m, (unsigned long)s);
+    drawText(2, 18, buf, COLOUR_ACCENT, 1);
+    snprintf(buf, sizeof(buf), "TCP %s", tcp_client_ip ? tcp_client_ip : "---");
+    drawText(2, 31, buf, COLOUR_FG, 1);
+    snprintf(buf, sizeof(buf), "USB idle %lus", (unsigned long)usb_idle_sec);
+    drawText(2, 44, buf, COLOUR_FG, 1);
+    snprintf(buf, sizeof(buf), "RX %lu TX %lu CRC %lu",
+             (unsigned long)rx_count, (unsigned long)tx_count,
+             (unsigned long)crc_errors);
+    drawText(2, 57, buf, crc_errors ? COLOUR_WARN : COLOUR_FG, 1);
+}
+
+void OledDisplay::showError(const char* msg) {
+    if (!_ready) return;
+    tft.fillScreen(COLOUR_BG);
+    tft.fillRect(0, 0, TFT_W, HEADER_H, COLOUR_ERR);
+    drawText(2, 3, "ERROR", COLOUR_FG, 1);
+    drawText(2, 24, msg ? msg : "", COLOUR_ERR, 2);
+}
+
+void OledDisplay::turnOff() {
+    if (!_ready) return;
+    digitalWrite(BOARD.pin_tft_rst, LOW);
+    writeActivePin(BOARD.pin_tft_bl, BOARD.tft_bl_active_high, false);
+    writeActivePin(BOARD.pin_tft_power, BOARD.tft_power_active_high, false);
+    _ready = false;
+}
+
+void OledDisplay::turnOn() {
+    begin();
+}
+
+#elif defined(BOARD_HELTEC_T114)
 
 #include "tft_display.h"
 #include "splash_logo.h"

--- a/firmware/src/tft_display.cpp
+++ b/firmware/src/tft_display.cpp
@@ -130,7 +130,9 @@ void OledDisplay::showSplash() {
 
 void OledDisplay::showStatus(uint32_t rx, uint32_t tx,
                              const char* ssid, const char* ip,
-                             const char* state, const char* version) {
+                             const char* state, const char* version,
+                             uint16_t battery_mv) {
+    (void)battery_mv;
     if (!_ready) return;
     tft.fillScreen(COLOUR_BG);
     drawHeader(_displayName, version);

--- a/firmware/tools/build_firmware_assets.py
+++ b/firmware/tools/build_firmware_assets.py
@@ -42,6 +42,11 @@ ENV_METADATA: dict[str, dict[str, str | bool]] = {
         "chip_family": "ESP32-S3",
         "web_manifest": True,
     },
+    "heltec_tracker_v2": {
+        "name": "Heltec Wireless Tracker V2 pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
     "ikoka_stick": {
         "name": "Ikoka Stick pyMC Modem",
         "chip_family": "ESP32-S3",
@@ -85,6 +90,7 @@ ENV_METADATA: dict[str, dict[str, str | bool]] = {
 BOARD_HEADER_TO_ENV = {
     "firmware/include/boards/heltec_v3.h": "heltec_v3",
     "firmware/include/boards/heltec_v4.h": "heltec_v4",
+    "firmware/include/boards/heltec_tracker_v2.h": "heltec_tracker_v2",
     "firmware/include/boards/ikoka_stick.h": "ikoka_stick",
     "firmware/include/boards/xiao_wio_sx1262.h": "xiao_wio_sx1262",
     "firmware/include/boards/rak3112_wismesh.h": "rak3112_wismesh",


### PR DESCRIPTION
Adds Heltec Wireless Tracker V2 firmware support, rebased onto current main.

Maintainer updates applied:
- Rebased the branch from old `dev` onto current `main` so it follows the current PR flow.
- Kept generated firmware assets out of the PR; `Build Firmware Assets` will produce `firmware/heltec_tracker_v2/` after merge to main.
- Added firmware asset-builder metadata and board-header mapping for `heltec_tracker_v2`.
- Updated README supported-board and per-board notes.
- Adapted Tracker V2 FEM pins to the current static GPIO facility instead of adding a second RF front-end API.
- Preserved existing nRF52 builds by fixing the C++ standard unflags and positional board initializers.

Validation run locally:
- `python3 firmware/tools/build_firmware_assets.py --variant heltec_tracker_v2 --plan`
- `python3 firmware/tools/build_firmware_assets.py --changed-from upstream/main --changed-to HEAD --variant auto --plan`
- `pio run -e heltec_tracker_v2`
- `pio run -e heltec_v4`
- `pio run -e heltec_t114`
- `pio run -e xiao_nrf52_wio`
