### PR TITLE
ci: add firmware asset builder workflow

### DIFF
--- a/.github/workflows/build-firmware-assets.yml
+++ b/.github/workflows/build-firmware-assets.yml
@@ -1,10 +1,6 @@
 name: Build Firmware Assets
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/build-firmware-assets.yml'
-      - 'firmware/**'
   push:
     branches:
       - main
@@ -77,11 +73,6 @@ jobs:
 
           before='${{ github.event.before }}'
           after='${{ github.sha }}'
-
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            before='${{ github.event.pull_request.base.sha }}'
-            after='${{ github.event.pull_request.head.sha }}'
-          fi
 
           python3 firmware/tools/build_firmware_assets.py \
             --variant '${{ steps.inputs.outputs.variant }}' \
@@ -179,7 +170,12 @@ jobs:
     needs:
       - select
       - build
-    if: github.event_name == 'workflow_dispatch' && inputs.commit_artifacts == true && needs.select.outputs.has_envs == 'true'
+    if: >
+      needs.select.outputs.has_envs == 'true' &&
+      (
+        (github.event_name == 'workflow_dispatch' && inputs.commit_artifacts == true) ||
+        (github.event_name == 'push' && github.ref_name == 'main')
+      )
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-firmware-assets.yml
+++ b/.github/workflows/build-firmware-assets.yml
@@ -96,10 +96,10 @@ jobs:
           echo "envs_json=$envs_json" >> "$GITHUB_OUTPUT"
           echo "Selected envs: $envs_json"
 
-  build:
+  build-manual-artifacts:
     name: Build ${{ matrix.env }}
     needs: select
-    if: needs.select.outputs.has_envs == 'true'
+    if: github.event_name == 'workflow_dispatch' && needs.select.outputs.has_envs == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -149,7 +149,7 @@ jobs:
         run: |
           set -euo pipefail
           clean_flag=''
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.clean }}" = "true" ]; then
+          if [ "${{ inputs.clean }}" = "true" ]; then
             clean_flag='--clean'
           fi
           python3 firmware/tools/build_firmware_assets.py \
@@ -165,17 +165,12 @@ jobs:
             firmware/${{ matrix.env }}/**
           if-no-files-found: error
 
-  commit-artifacts:
-    name: Commit generated firmware assets
+  commit-manual-artifacts:
+    name: Commit manual firmware assets
     needs:
       - select
-      - build
-    if: >
-      needs.select.outputs.has_envs == 'true' &&
-      (
-        (github.event_name == 'workflow_dispatch' && inputs.commit_artifacts == true) ||
-        (github.event_name == 'push' && github.ref_name == 'main')
-      )
+      - build-manual-artifacts
+    if: github.event_name == 'workflow_dispatch' && inputs.commit_artifacts == true && needs.select.outputs.has_envs == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -209,6 +204,89 @@ jobs:
           PY
 
       - name: Commit firmware assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          while read -r env; do
+            [ -n "$env" ] || continue
+            git add "firmware/$env"
+          done < <(python3 - <<'PY'
+          import json
+          for env in json.loads('${{ needs.select.outputs.envs_json }}'):
+              print(env)
+          PY
+          )
+
+          if git diff --cached --quiet; then
+            echo 'No firmware artifact changes to commit.'
+            exit 0
+          fi
+
+          git commit -m 'firmware: update generated firmware assets [skip ci]'
+          git push
+
+  build-and-commit-main:
+    name: Build and commit main firmware assets
+    needs: select
+    if: github.event_name == 'push' && github.ref_name == 'main' && needs.select.outputs.has_envs == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Restore PlatformIO cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.platformio
+            .venv-pio
+          key: ${{ runner.os }}-platformio-main-${{ hashFiles('firmware/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-platformio-main-
+            ${{ runner.os }}-platformio-
+
+      - name: Ensure PlatformIO is available
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v pio >/dev/null 2>&1; then
+            echo "PIO=$(command -v pio)" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          if [ ! -x "$GITHUB_WORKSPACE/.venv-pio/bin/pio" ]; then
+            python -m venv "$GITHUB_WORKSPACE/.venv-pio"
+            "$GITHUB_WORKSPACE/.venv-pio/bin/python" -m pip install --upgrade pip
+            "$GITHUB_WORKSPACE/.venv-pio/bin/python" -m pip install platformio
+          fi
+          echo "PIO=$GITHUB_WORKSPACE/.venv-pio/bin/pio" >> "$GITHUB_ENV"
+
+      - name: Build selected firmware assets without artifact upload
+        shell: bash
+        run: |
+          set -euo pipefail
+          variants=$(python3 - <<'PY'
+          import json
+          print(','.join(json.loads('${{ needs.select.outputs.envs_json }}')))
+          PY
+          )
+          python3 firmware/tools/build_firmware_assets.py \
+            --variant "$variants" \
+            --pio "$PIO"
+
+      - name: Commit firmware assets to main
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/build-firmware-assets.yml
+++ b/.github/workflows/build-firmware-assets.yml
@@ -1,0 +1,238 @@
+name: Build Firmware Assets
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/build-firmware-assets.yml'
+      - 'firmware/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build-firmware-assets.yml'
+      - 'firmware/**'
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: 'PlatformIO env to build: auto, all, or comma-separated env names'
+        required: false
+        default: 'auto'
+      clean:
+        description: 'Run pio clean before each selected build'
+        required: false
+        default: false
+        type: boolean
+      commit_artifacts:
+        description: 'Commit generated firmware/<env>/ artifacts back to this branch'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+env:
+  # Opt into the GitHub Actions Node 24 runtime now so the repo does not
+  # emit Node.js 20 deprecation warnings on checkout/cache/artifact actions.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  select:
+    name: Select firmware variants
+    runs-on: ubuntu-latest
+    outputs:
+      envs_json: ${{ steps.plan.outputs.envs_json }}
+      has_envs: ${{ steps.plan.outputs.has_envs }}
+      variant_input: ${{ steps.inputs.outputs.variant }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve inputs
+        id: inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          variant='auto'
+          clean='false'
+          commit_artifacts='false'
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            variant='${{ inputs.variant }}'
+            clean='${{ inputs.clean }}'
+            commit_artifacts='${{ inputs.commit_artifacts }}'
+          fi
+
+          echo "variant=$variant" >> "$GITHUB_OUTPUT"
+          echo "clean=$clean" >> "$GITHUB_OUTPUT"
+          echo "commit_artifacts=$commit_artifacts" >> "$GITHUB_OUTPUT"
+
+      - name: Plan selected variants
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          before='${{ github.event.before }}'
+          after='${{ github.sha }}'
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            before='${{ github.event.pull_request.base.sha }}'
+            after='${{ github.event.pull_request.head.sha }}'
+          fi
+
+          python3 firmware/tools/build_firmware_assets.py \
+            --variant '${{ steps.inputs.outputs.variant }}' \
+            --changed-from "$before" \
+            --changed-to "$after" \
+            --plan
+
+          if [ -s firmware/.selected_firmware_envs ]; then
+            envs_json=$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+          envs = [line.strip() for line in Path('firmware/.selected_firmware_envs').read_text().splitlines() if line.strip()]
+          print(json.dumps(envs))
+          PY
+          )
+            echo "has_envs=true" >> "$GITHUB_OUTPUT"
+          else
+            envs_json='[]'
+            echo "has_envs=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "envs_json=$envs_json" >> "$GITHUB_OUTPUT"
+          echo "Selected envs: $envs_json"
+
+  build:
+    name: Build ${{ matrix.env }}
+    needs: select
+    if: needs.select.outputs.has_envs == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJson(needs.select.outputs.envs_json) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Restore PlatformIO cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            .venv-pio
+          key: ${{ runner.os }}-platformio-${{ matrix.env }}-${{ hashFiles('firmware/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-platformio-${{ matrix.env }}-
+            ${{ runner.os }}-platformio-
+
+      - name: Ensure PlatformIO is available
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v pio >/dev/null 2>&1; then
+            echo "PIO=$(command -v pio)" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          if [ ! -x "$GITHUB_WORKSPACE/.venv-pio/bin/pio" ]; then
+            python -m venv "$GITHUB_WORKSPACE/.venv-pio"
+            "$GITHUB_WORKSPACE/.venv-pio/bin/python" -m pip install --upgrade pip
+            "$GITHUB_WORKSPACE/.venv-pio/bin/python" -m pip install platformio
+          fi
+          echo "PIO=$GITHUB_WORKSPACE/.venv-pio/bin/pio" >> "$GITHUB_ENV"
+
+      - name: Build and stage firmware assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          clean_flag=''
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.clean }}" = "true" ]; then
+            clean_flag='--clean'
+          fi
+          python3 firmware/tools/build_firmware_assets.py \
+            --variant '${{ matrix.env }}' \
+            --pio "$PIO" \
+            $clean_flag
+
+      - name: Upload firmware assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.env }}
+          path: |
+            firmware/${{ matrix.env }}/**
+          if-no-files-found: error
+
+  commit-artifacts:
+    name: Commit generated firmware assets
+    needs:
+      - select
+      - build
+    if: github.event_name == 'workflow_dispatch' && inputs.commit_artifacts == true && needs.select.outputs.has_envs == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Download generated firmware assets
+        uses: actions/download-artifact@v4
+        with:
+          pattern: firmware-*
+          path: _firmware_artifacts
+
+      - name: Stage downloaded assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import shutil
+          root = Path('_firmware_artifacts')
+          for artifact in root.glob('firmware-*'):
+              env = artifact.name.removeprefix('firmware-')
+              dest = Path('firmware') / env
+              if dest.exists():
+                  shutil.rmtree(dest)
+              shutil.copytree(artifact, dest)
+              print(f'staged {dest}')
+          PY
+
+      - name: Commit firmware assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          while read -r env; do
+            [ -n "$env" ] || continue
+            git add "firmware/$env"
+          done < <(python3 - <<'PY'
+          import json
+          for env in json.loads('${{ needs.select.outputs.envs_json }}'):
+              print(env)
+          PY
+          )
+
+          if git diff --cached --quiet; then
+            echo 'No firmware artifact changes to commit.'
+            exit 0
+          fi
+
+          git commit -m 'firmware: update generated firmware assets [skip ci]'
+          git push

--- a/.github/workflows/build-firmware-assets.yml
+++ b/.github/workflows/build-firmware-assets.yml
@@ -46,7 +46,7 @@ jobs:
       variant_input: ${{ steps.inputs.outputs.variant }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -117,17 +117,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Restore PlatformIO cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.platformio
@@ -167,7 +167,7 @@ jobs:
             $clean_flag
 
       - name: Upload firmware assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware-${{ matrix.env }}
           path: |
@@ -184,13 +184,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
       - name: Download generated firmware assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: firmware-*
           path: _firmware_artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ __pycache__/
 *.pyc
 *.pyo
 *.egg-info/
+.venv-pio/
+firmware/.selected_firmware_envs
 
 # macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Native install, Docker deployment, firmware flashing (esptool / PlatformIO /
 OTA), Wi-Fi provisioning and the full pymc_core integration steps are
 documented in [INSTALL.md](INSTALL.md).
 
+## Firmware asset builds
+
+The `Build Firmware Assets` GitHub workflow uses
+`firmware/tools/build_firmware_assets.py` to build PlatformIO envs and stage
+flasher-ready outputs in `firmware/<env>/`.  On PR/push it builds affected
+envs for validation and uploads artifacts.  On manual dispatch it can build
+`auto`, `all`, or specific envs and, when `commit_artifacts=true`, commit the
+updated `firmware/<env>/` binaries, manifests, and SHA256 sums back to the
+branch.
+
 ## Per-board pin map
 
 All board-specific GPIOs and policies live in

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ The `Build Firmware Assets` GitHub workflow uses
 `firmware/tools/build_firmware_assets.py` to build PlatformIO envs and stage
 flasher-ready outputs in `firmware/<env>/`.  Pull requests do not build
 firmware.  Pushes to `main` build affected envs and commit updated
-`firmware/<env>/` binaries, manifests, and SHA256 sums back to `main`.
-Manual dispatch can build `auto`, `all`, or specific envs from any branch;
-manual runs only commit generated files when `commit_artifacts=true`.
+`firmware/<env>/` binaries, manifests, and SHA256 sums back to `main` without
+uploading Actions artifacts.  Manual dispatch can build `auto`, `all`, or
+specific envs from any branch; manual runs upload Actions artifacts for review
+and only commit generated files when `commit_artifacts=true`.
 
 ## Per-board pin map
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ documented in [INSTALL.md](INSTALL.md).
 
 The `Build Firmware Assets` GitHub workflow uses
 `firmware/tools/build_firmware_assets.py` to build PlatformIO envs and stage
-flasher-ready outputs in `firmware/<env>/`.  On PR/push it builds affected
-envs for validation and uploads artifacts.  On manual dispatch it can build
-`auto`, `all`, or specific envs and, when `commit_artifacts=true`, commit the
-updated `firmware/<env>/` binaries, manifests, and SHA256 sums back to the
-branch.
+flasher-ready outputs in `firmware/<env>/`.  Pull requests do not build
+firmware.  Pushes to `main` build affected envs and commit updated
+`firmware/<env>/` binaries, manifests, and SHA256 sums back to `main`.
+Manual dispatch can build `auto`, `all`, or specific envs from any branch;
+manual runs only commit generated files when `commit_artifacts=true`.
 
 ## Per-board pin map
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -31,7 +31,7 @@ build_flags =
     -DDEFAULT_PREAMBLE=16
 
 [env:heltec_v3]
-platform = espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
 board = heltec_wifi_lora_32_V3
 ; OTA upload (after first flash over USB):
 ;   pio run -e heltec_v3 -t upload --upload-port heltec-<mac3>.local
@@ -48,7 +48,7 @@ build_flags =
     -DBOARD_HELTEC_V3
 
 [env:ikoka_stick]
-platform = espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
 board = seeed_xiao_esp32s3
 ; OTA upload after first USB flash:
 ;   pio run -e ikoka_stick -t upload --upload-port ikoka-<mac3>.local
@@ -65,7 +65,7 @@ build_flags =
     -DBOARD_IKOKA_STICK
 
 [env:xiao_wio_sx1262]
-platform = espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
 board = seeed_xiao_esp32s3
 ; Seeed XIAO ESP32-S3 + Wio-SX1262 expansion (bare SX1262, +22 dBm max).
 ; Wio-SX1262 connector on the underside of the XIAO routes:
@@ -83,7 +83,7 @@ build_flags =
     -DBOARD_XIAO_WIO_SX1262
 
 [env:rak3112_wismesh]
-platform = espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 ; RAK3112 WisDuo module on a WisMesh carrier (datasheet ref:
 ; _incoming/WisDuo - RAK3112 ...). 16 MB QIO flash + 8 MB octal PSRAM
@@ -122,7 +122,7 @@ build_flags =
     -DBOARD_ESP32_P4_NANO
 
 [env:lilygo_t3s3]
-platform = espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
 board = lilygo-t3-s3
 ; LilyGO T-Lora T3-S3 v1.2 / v1.3 — bare SX1262, no PA, no E22 module.
 ; Confirmed from V1.3 schematic: USB-C goes straight to the ESP32-S3's

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,5 +1,5 @@
 ; =============================================================
-; pymc_usb LoRa Modem — Serial-to-SX1262 bridge for pymc_core
+; pymc_modem LoRa Modem — Serial-to-SX1262 bridge for pymc_core
 ; Two boards share the same source tree; pick one per build:
 ;   pio run -e heltec_v3      → Heltec WiFi LoRa 32 V3 (bare SX1262)
 ;   pio run -e ikoka_stick    → XIAO ESP32-S3 + Ebyte E22-P868M30S

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,5 +1,5 @@
 // =============================================================
-// main.cpp — pymc_usb LoRa Modem firmware
+// main.cpp — pymc_modem LoRa Modem firmware
 // Serial + Wi-Fi/TCP bridge to SX1262 for pymc_core on RPi.
 //
 // Supported boards (selected at compile time via -DBOARD_<name>):

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -536,7 +536,7 @@ static bool checkAuth() {
         Serial.printf("[OTA] reject non-LAN client %u.%u.%u.%u\n",
                       addr[0], addr[1], addr[2], addr[3]);
         httpServer->send(403, "text/plain",
-                         "Forbidden: pymc_usb modem accepts LAN clients only.\n");
+                         "Forbidden: pymc_modem accepts LAN clients only.\n");
         return false;
     }
     if (httpPassword.length() == 0) httpPassword = DEFAULT_HTTP_PASSWORD;

--- a/firmware/tools/build_firmware_assets.py
+++ b/firmware/tools/build_firmware_assets.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Build PlatformIO firmware envs and stage flasher-ready assets.
+
+This is intentionally repo-local and small: GitHub Actions calls it, but it
+also works from a developer shell.  It discovers [env:<name>] blocks from
+firmware/platformio.ini, optionally narrows the build set from git changes,
+builds each selected env, then copies artifacts into firmware/<env>/.
+
+ESP32-family envs get:
+  bootloader.bin, partitions.bin, firmware.bin, manifest.json, SHA256SUMS.txt
+
+nRF52 envs get:
+  firmware.hex, firmware.zip, SHA256SUMS.txt
+"""
+from __future__ import annotations
+
+import argparse
+import configparser
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FIRMWARE = ROOT / "firmware"
+PLATFORMIO_INI = FIRMWARE / "platformio.ini"
+SELECTED_ENVS_FILE = FIRMWARE / ".selected_firmware_envs"
+
+# Env-specific metadata used for flasher manifests and names.  Envs omitted
+# here still build/copy artifacts; they just get conservative defaults.
+ENV_METADATA: dict[str, dict[str, str | bool]] = {
+    "heltec_v3": {
+        "name": "Heltec WiFi LoRa 32 V3 pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
+    "ikoka_stick": {
+        "name": "Ikoka Stick pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
+    "xiao_wio_sx1262": {
+        "name": "Seeed XIAO Wio-SX1262 pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
+    "rak3112_wismesh": {
+        "name": "RAK3112 WisMesh pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
+    "esp32_p4_nano": {
+        "name": "WaveShare ESP32-P4-Nano pyMC Modem",
+        "chip_family": "ESP32-P4",
+        # ESP Web Tools support for P4 is still less common; artifacts are
+        # staged, but a browser-flasher manifest is deliberately skipped.
+        "web_manifest": False,
+    },
+    "lilygo_t3s3": {
+        "name": "LilyGO T-LoRa T3-S3 pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
+    "heltec_t114": {
+        "name": "Heltec T114 pyMC Modem",
+        "chip_family": "NRF52",
+        "web_manifest": False,
+    },
+    "xiao_nrf52_wio": {
+        "name": "Seeed XIAO nRF52840 Wio-SX1262 pyMC Modem",
+        "chip_family": "NRF52",
+        "web_manifest": False,
+    },
+}
+
+# Board headers generally map 1:1 to env names in this repo.
+BOARD_HEADER_TO_ENV = {
+    "firmware/include/boards/heltec_v3.h": "heltec_v3",
+    "firmware/include/boards/ikoka_stick.h": "ikoka_stick",
+    "firmware/include/boards/xiao_wio_sx1262.h": "xiao_wio_sx1262",
+    "firmware/include/boards/rak3112_wismesh.h": "rak3112_wismesh",
+    "firmware/include/boards/esp32_p4_nano.h": "esp32_p4_nano",
+    "firmware/include/boards/lilygo_t3s3.h": "lilygo_t3s3",
+    "firmware/include/boards/heltec_t114.h": "heltec_t114",
+    "firmware/include/boards/xiao_nrf52_wio.h": "xiao_nrf52_wio",
+}
+
+# Changes here are shared enough that building all envs is safer.
+SHARED_PREFIXES = (
+    ".github/workflows/",
+    "firmware/src/",
+    "firmware/include/",
+    "firmware/variants/",
+    "firmware/boards/",
+)
+SHARED_FILES = {
+    "firmware/platformio.ini",
+    "firmware/build_release.sh",
+    "firmware/tools/build_firmware_assets.py",
+}
+
+
+def run(cmd: list[str], cwd: Path = ROOT) -> str:
+    print("+ " + " ".join(cmd), flush=True)
+    completed = subprocess.run(cmd, cwd=cwd, check=False, text=True,
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if completed.stdout:
+        print(completed.stdout, end="")
+    completed.check_returncode()
+    return completed.stdout
+
+
+def discover_envs() -> list[str]:
+    envs: list[str] = []
+    for line in PLATFORMIO_INI.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[env:") and stripped.endswith("]"):
+            envs.append(stripped[len("[env:"):-1])
+    if not envs:
+        raise SystemExit(f"No [env:<name>] blocks found in {PLATFORMIO_INI}")
+    return envs
+
+
+def git_changed_files(base: str | None, head: str | None) -> list[str]:
+    if not base or not head:
+        return []
+    # GitHub sets github.event.before to all zeroes for the first push of a
+    # new branch.  That is not a real commit, so there is no diff range to
+    # inspect; let auto mode fall back to building all envs.
+    if set(base) == {"0"}:
+        print("Changed-file base is the all-zero new-branch sentinel; building all envs.")
+        return []
+    try:
+        out = run(["git", "diff", "--name-only", f"{base}...{head}"], ROOT)
+    except subprocess.CalledProcessError:
+        out = run(["git", "diff", "--name-only", base, head], ROOT)
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def select_envs(requested: str, all_envs: list[str], base: str | None, head: str | None) -> list[str]:
+    requested = requested.strip()
+    if requested == "all":
+        return all_envs
+    if requested != "auto":
+        requested_envs = [part.strip() for part in requested.split(",") if part.strip()]
+        unknown = sorted(set(requested_envs) - set(all_envs))
+        if unknown:
+            raise SystemExit(f"Unknown env(s): {', '.join(unknown)}. Known: {', '.join(all_envs)}")
+        return requested_envs
+
+    changed = git_changed_files(base, head)
+    if not changed:
+        print("No changed-file range supplied; auto mode will build all envs.")
+        return all_envs
+
+    print("Changed files:")
+    for path in changed:
+        print(f"  {path}")
+
+    selected: set[str] = set()
+    for path in changed:
+        if path in SHARED_FILES:
+            print(f"Shared file changed ({path}); building all envs.")
+            return all_envs
+        if path in BOARD_HEADER_TO_ENV:
+            selected.add(BOARD_HEADER_TO_ENV[path])
+            continue
+        if path.startswith("firmware/include/boards/"):
+            # Unknown board header: safest option is all envs.
+            print(f"Unknown board header changed ({path}); building all envs.")
+            return all_envs
+        if path.startswith("firmware/") and not any(
+            path.startswith(f"firmware/{env}/") for env in all_envs
+        ):
+            if any(path.startswith(prefix) for prefix in SHARED_PREFIXES):
+                print(f"Shared firmware path changed ({path}); building all envs.")
+                return all_envs
+
+    if selected:
+        return [env for env in all_envs if env in selected]
+
+    print("Only docs/prebuilt artifacts changed; no firmware envs selected.")
+    return []
+
+
+def pio_executable(cli_value: str | None) -> str:
+    if cli_value:
+        return cli_value
+    return os.environ.get("PIO") or shutil.which("pio") or str(Path.home() / ".platformio/penv/bin/pio")
+
+
+def clean_dest(dest: Path) -> None:
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_sha256s(dest: Path, files: list[Path]) -> None:
+    lines = [f"{sha256_file(path)}  {path.name}" for path in files if path.exists()]
+    (dest / "SHA256SUMS.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def firmware_version(env: str) -> str:
+    main_cpp = FIRMWARE / "src/main.cpp"
+    base = "unknown"
+    if main_cpp.exists():
+        for line in main_cpp.read_text(encoding="utf-8", errors="ignore").splitlines():
+            marker = "#define FW_VERSION_BASE"
+            if line.strip().startswith(marker):
+                parts = line.split('"')
+                if len(parts) >= 2:
+                    base = parts[1]
+                break
+    # Board fw_suffix normally matches env enough for flasher display.
+    return f"{base}-{env}"
+
+
+def write_esp_manifest(env: str, dest: Path) -> Path | None:
+    meta = ENV_METADATA.get(env, {})
+    if meta.get("web_manifest") is not True:
+        return None
+    chip_family = str(meta.get("chip_family", "ESP32"))
+    manifest = {
+        "name": str(meta.get("name", f"{env} pyMC Modem")),
+        "version": firmware_version(env),
+        "new_install_prompt_erase": True,
+        "builds": [
+            {
+                "chipFamily": chip_family,
+                "parts": [
+                    {"path": "bootloader.bin", "offset": 0},
+                    {"path": "partitions.bin", "offset": 0x8000},
+                    {"path": "firmware.bin", "offset": 0x10000},
+                ],
+            }
+        ],
+    }
+    out = dest / "manifest.json"
+    out.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return out
+
+
+def collect_env(env: str) -> None:
+    out_dir = FIRMWARE / ".pio/build" / env
+    dest = FIRMWARE / env
+    clean_dest(dest)
+
+    # nRF52 Adafruit builds produce firmware.hex + firmware.zip.
+    hex_file = out_dir / "firmware.hex"
+    zip_file = out_dir / "firmware.zip"
+    bin_file = out_dir / "firmware.bin"
+    copied: list[Path] = []
+
+    if hex_file.exists() and not bin_file.exists():
+        for source in (hex_file, zip_file):
+            if not source.exists():
+                raise SystemExit(f"Expected artifact missing for {env}: {source}")
+            target = dest / source.name
+            shutil.copy2(source, target)
+            copied.append(target)
+        write_sha256s(dest, copied)
+        print(f"Staged nRF52 artifacts in {dest.relative_to(ROOT)}")
+        return
+
+    for name in ("bootloader.bin", "partitions.bin", "firmware.bin"):
+        source = out_dir / name
+        if not source.exists():
+            raise SystemExit(f"Expected artifact missing for {env}: {source}")
+        target = dest / name
+        shutil.copy2(source, target)
+        copied.append(target)
+
+    manifest = write_esp_manifest(env, dest)
+    if manifest:
+        copied.append(manifest)
+    write_sha256s(dest, copied)
+    print(f"Staged ESP artifacts in {dest.relative_to(ROOT)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--variant", default="auto",
+                        help="auto, all, or comma-separated PlatformIO env names")
+    parser.add_argument("--changed-from", default=os.environ.get("GITHUB_EVENT_BEFORE"))
+    parser.add_argument("--changed-to", default=os.environ.get("GITHUB_SHA"))
+    parser.add_argument("--pio", default=None, help="Path to PlatformIO executable")
+    parser.add_argument("--clean", action="store_true", help="Run pio clean before building")
+    parser.add_argument("--plan", action="store_true", help="Only print selected envs; do not build")
+    args = parser.parse_args()
+
+    all_envs = discover_envs()
+    selected = select_envs(args.variant, all_envs, args.changed_from, args.changed_to)
+    SELECTED_ENVS_FILE.write_text("\n".join(selected) + ("\n" if selected else ""), encoding="utf-8")
+
+    print("Selected envs: " + (", ".join(selected) if selected else "<none>"))
+    if args.plan or not selected:
+        return 0
+
+    pio = pio_executable(args.pio)
+    for env in selected:
+        if args.clean:
+            run([pio, "run", "-e", env, "--target", "clean"], FIRMWARE)
+        run([pio, "run", "-e", env], FIRMWARE)
+        collect_env(env)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/firmware/variants/Heltec_T114_Board/variant.h
+++ b/firmware/variants/Heltec_T114_Board/variant.h
@@ -24,7 +24,7 @@
 // VDD has time to come up before the SPI traffic starts.
 #define PIN_3V3_EN              (38)
 
-// Battery sense (P0.04, A0). Not used by pymc_usb yet but kept
+// Battery sense (P0.04, A0). Not used by pymc_modem yet but kept
 // so analogRead() works if we ever expose it.
 #define BATTERY_PIN             (4)
 #define ADC_MULTIPLIER          (4.90F)
@@ -46,7 +46,7 @@
 #define PIN_SERIAL1_TX          (39)
 
 // UART2 (Serial2) = the protocol header pins silked 0.09/0.10.
-// pymc_usb uses these for the host-facing UART when the board
+// pymc_modem uses these for the host-facing UART when the board
 // is wired to a sector-array controller instead of USB.
 #define PIN_SERIAL2_RX          (9)
 #define PIN_SERIAL2_TX          (10)
@@ -88,7 +88,7 @@
 
 // External QSPI flash (MX25R1635F on T114) — required by the
 // Adafruit BSP's Adafruit_LittleFS init even if we never write
-// to it from pymc_usb.
+// to it from pymc_modem.
 #define EXTERNAL_FLASH_DEVICES  MX25R1635F
 #define EXTERNAL_FLASH_USE_QSPI
 


### PR DESCRIPTION
## Summary

This PR adds an automated firmware asset build pipeline for pyMC Modem firmware.

A new GitHub Actions workflow and build helper script can build PlatformIO firmware environments, generate flasher-ready firmware packages, create manifests and checksums, and optionally commit generated assets back to the repository.

The workflow is intentionally designed so firmware builds do **not** run on pull requests. Firmware assets are generated only after changes land on `main` or when manually triggered from GitHub Actions.

## Behavior

### Pull Requests

* No firmware builds.
* No artifact uploads.
* No generated firmware commits.

### Pushes to `main`

* Detects affected firmware environments.
* Builds selected firmware targets.
* Generates firmware assets under `firmware/<env>/`.
* Commits generated firmware assets back to `main`.
* Does not upload GitHub Actions artifacts.

### Manual Workflow Dispatch

* Supports `auto`, `all`, or specific environment lists.
* Uploads build artifacts for download and review.
* Optionally commits generated firmware assets when `commit_artifacts=true`.

## Main Changes

### Firmware Build Workflow

Added `.github/workflows/build-firmware-assets.yml`:

* Runs on pushes to `main` and manual dispatch.
* Uses PlatformIO caching to reduce build times.
* Separates manual artifact builds from automated main-branch asset generation.
* Avoids artifact uploads during normal main-branch builds.

### Firmware Asset Builder

Added `firmware/tools/build_firmware_assets.py`:

* Discovers PlatformIO environments automatically.
* Supports automatic, all-target, or explicit environment selection.
* Builds selected firmware targets.
* Generates firmware packages, checksums, and manifests.
* Produces ESP Web Tools-compatible manifests for supported ESP targets.

### PlatformIO Updates

Updated `firmware/platformio.ini`:

* Renamed remaining top-level references from `pymc_usb` to `pymc_modem`.
* Pinned ESP32-S3 targets to the Arduino-ESP32 3.x (`pioarduino`) platform.
* Fixes hosted-runner build failures caused by older Arduino-ESP32 2.x toolchains.

### Documentation

* Added firmware build workflow documentation to the README.
* Documented manual dispatch behavior.
* Clarified how generated firmware assets are produced and committed.

### Cleanup

* Added `.venv-pio/` and generated environment-selection files to `.gitignore`.
* Updated remaining user-facing firmware references from `pymc_usb` to `pymc_modem` in touched files.

## Validation

* Verified workflow configuration and trigger behavior.
* Confirmed no `pull_request` firmware builds occur.
* Confirmed artifact uploads are excluded from automated main-branch builds.
* Passed `git diff --check`.
* Successfully completed local PlatformIO builds.
* Successfully completed a full manual GitHub Actions build across all supported firmware targets.

## Notes

Generated firmware binaries are intentionally not included in this PR. They will be produced automatically after merge or through a manual workflow run with asset commits enabled.

Working version can be found at. 

https://github.com/yellowcooln/pymc_modem/tree/main/firmware