### PR TITLE
firmware: add Station G2 board support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ All commands assume you are in the repository root `pymc_modem/`.
 
 ## 1. Flash the firmware
 
-The same source tree builds five binaries; pick the env that matches
+The same source tree builds one firmware target per board; pick the env that matches
 your board:
 
 | Board | PlatformIO env | mDNS name | Network |
@@ -13,13 +13,13 @@ your board:
 | Ikoka Stick (XIAO ESP32-S3 + E22-P868M30S) | `ikoka_stick` | `ikoka-<mac3>.local` | Wi-Fi |
 | LilyGO T-LoRa T3-S3 v1.2/v1.3 | `lilygo_t3s3` | `lilygo-t3s3-<mac3>.local` | Wi-Fi |
 | RAK3112 WisMesh | `rak3112_wismesh` | `rak3112-<mac3>.local` | Wi-Fi |
+| B&Q Consulting Station G2 | `station_g2` | `station-g2-<mac3>.local` | Wi-Fi |
 | WaveShare ESP32-P4-Nano (+ off-board E22) | `esp32_p4_nano` | `p4nano-<mac3>.local` | **Ethernet or Wi-Fi** (runtime auto-select; cable plugged → ETH, no link → WiFi fallback. Both at once is unstable with radio active — see README "Porting to another ESP32-P4 board") |
 
-The `esp32_p4_nano` env uses the
+The `esp32_p4_nano` and `station_g2` envs use the
 [pioarduino fork](https://github.com/pioarduino/platform-espressif32)
-(pinned in `platformio.ini`) because vanilla `platformio/espressif32`
-doesn't ship ESP32-P4 support yet; first build will fetch the platform
-package once.
+(pinned in `platformio.ini`) for the Arduino-ESP32 3.x / ESP-IDF 5.x
+toolchain; first build will fetch the platform package once.
 
 ### 1a. Prebuilt binaries (no PlatformIO)
 
@@ -33,14 +33,14 @@ artefacts each:
 | `firmware/<env>/firmware.bin`     | `0x10000` | ~830 kB|
 
 `<env>` is one of: `heltec_v3`, `ikoka_stick`, `lilygo_t3s3`,
-`rak3112_wismesh`, `esp32_p4_nano`.
+`rak3112_wismesh`, `esp32_p4_nano`, `station_g2`.
 
 ```bash
 pip install esptool
 
 # Full flash (fresh board, first install) — replace the ENV/CHIP pair
 # with the row that matches your board:
-ENV=heltec_v3      ; CHIP=esp32s3   # also for ikoka_stick / lilygo_t3s3 / rak3112_wismesh
+ENV=heltec_v3      ; CHIP=esp32s3   # also for ikoka_stick / lilygo_t3s3 / rak3112_wismesh / station_g2
 # ENV=esp32_p4_nano ; CHIP=esp32p4
 
 esptool.py --chip $CHIP --port /dev/ttyUSB0 --baud 921600 write_flash \
@@ -94,7 +94,7 @@ curl -u admin:password -F firmware=@.pio/build/<env>/firmware.bin \
 ```
 
 Hostname stems are listed in §1 (e.g. `heltec`, `ikoka`,
-`lilygo-t3s3`, `rak3112`, `p4nano`). The board reboots after upload.
+`lilygo-t3s3`, `rak3112`, `station-g2`, `p4nano`). The board reboots after upload.
 The HTTP OTA page uses Basic Auth with username `admin` and default
 password `password`; change it from the OTA page after first network boot.
 Rollback is **not** automatic on a broken image — keep the USB cable

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Ethernet) wired LAN.
 | **Seeed XIAO Wio-SX1262**                                                                                   | XIAO ESP32-S3                | bare SX1262                | Wi-Fi    |
 | **LilyGO T-LoRa T3-S3** v1.2/v1.3                                                                           | ESP32-S3                     | bare SX1262 + OLED         | Wi-Fi    |
 | **RAK3112 WisMesh**                                                                                         | ESP32-S3 (module)            | SX1262 in-module           | Wi-Fi    |
+| **B&Q Consulting Station G2**                                                                                | ESP32-S3                     | SX1262 + 35 dBm PA/LNA     | Wi-Fi    |
 | **WaveShare ESP32-P4-Nano**                                                                                 | ESP32-P4 (RISC-V) + ESP32-C6 | E22 (off-board, optional)  | **Ethernet *or* Wi-Fi** — runtime auto-select: cable plugged → Ethernet wins, no link → fall back to Wi-Fi via C6 SDIO bridge. Both at once is unstable with the radio attached, see [P4-Nano notes](#porting-to-another-esp32-p4-board) |
 | **Heltec T114**                                                                                             | nRF52840                     | bare SX1262 + TFT 135×240  | **none** — USB-CDC + UART only |
 | **Seeed XIAO nRF52840 + Wio-SX1262**                                                                        | XIAO nRF52840                | bare SX1262                | **none** — USB-CDC only |
@@ -102,6 +103,7 @@ Per-board highlights (full pin numbers in the headers, mDNS prefix is
 - **XIAO Wio-SX1262** — Seeed XIAO ESP32-S3 + bare SX1262, no OLED.
 - **LilyGO T3-S3** — bare SX1262 + onboard SSD1306, native USB-CDC.
 - **RAK3112 WisMesh** — SX1262 inside the RAK3112 module, no OLED.
+- **Station G2** — SX1262 + high-power PA/LNA, SH1107 display currently disabled, max SX1262 drive capped at 19 dBm.
 - **WaveShare ESP32-P4-Nano** — RISC-V P4 + C6 + IP101GRI Ethernet PHY + off-board E22, runtime ETH-or-Wi-Fi (never both, see below).
 - **Heltec T114** — nRF52840 + bare SX1262 + ST7789 TFT 135×240, **no Wi-Fi/TCP/network OTA**; USB-CDC + UART transport only, OTA via Adafruit nRF52 DFU (USB) or in-app `CMD_OTA_*` over the protocol transport.
 - **Seeed XIAO nRF52840 + Wio-SX1262** (SKU 102010710) — XIAO nRF52840 + bare SX1262 on the Wio-SX1262 carrier, BLE 5.0 hardware unused, **no Wi-Fi/TCP/network OTA**, no display; native USB-CDC transport only, OTA via Adafruit nRF52 DFU (UF2 disk on double-click reset) or in-app `CMD_OTA_*`.

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -231,6 +231,8 @@ extern const BoardConfig BOARD;
 #  include "boards/xiao_wio_sx1262.h"
 #elif defined(BOARD_XIAO_NRF52_WIO)
 #  include "boards/xiao_nrf52_wio.h"
+#elif defined(BOARD_STATION_G2)
+#  include "boards/station_g2.h"
 #else
-#  error "No board selected — add one of -DBOARD_HELTEC_V3 / -DBOARD_HELTEC_V4 / -DBOARD_IKOKA_STICK / -DBOARD_LILYGO_T3S3 / -DBOARD_RAK3112_WISMESH / -DBOARD_ESP32_P4_NANO / -DBOARD_HELTEC_T114 / -DBOARD_HELTEC_TRACKER_V2 / -DBOARD_XIAO_WIO_SX1262 / -DBOARD_XIAO_NRF52_WIO to platformio.ini build_flags"
+#  error "No board selected — add one of -DBOARD_HELTEC_V3 / -DBOARD_HELTEC_V4 / -DBOARD_IKOKA_STICK / -DBOARD_LILYGO_T3S3 / -DBOARD_RAK3112_WISMESH / -DBOARD_ESP32_P4_NANO / -DBOARD_HELTEC_T114 / -DBOARD_HELTEC_TRACKER_V2 / -DBOARD_XIAO_WIO_SX1262 / -DBOARD_XIAO_NRF52_WIO / -DBOARD_STATION_G2 to platformio.ini build_flags"
 #endif

--- a/firmware/include/boards/station_g2.h
+++ b/firmware/include/boards/station_g2.h
@@ -33,9 +33,9 @@ inline const BoardConfig BOARD = {
         .dio2_as_rf_switch = true,
     },
 
-    // Built-in OLED is SH1107. Disable until the display backend supports it.
-    .pin_i2c_sda      = -1,
-    .pin_i2c_scl      = -1,
+    // Built-in OLED is SH1107 on the Station G2/G3 shared I2C bus.
+    .pin_i2c_sda      = 5,
+    .pin_i2c_scl      = 6,
     .pin_i2c_oled_rst = -1,
     .pin_vext_enable_low = -1,
 

--- a/firmware/include/boards/station_g2.h
+++ b/firmware/include/boards/station_g2.h
@@ -1,0 +1,63 @@
+// =============================================================
+// boards/station_g2.h — B&Q Consulting Station G2
+//
+// Hardware refs:
+//   * https://wiki.uniteng.com/en/meshtastic/station-g2
+//
+// ESP32-S3 + SX1262 with an external high-power PA/LNA front end. The
+// final RF output can be much higher than the SX1262 drive level, so keep
+// max_tx_power_dbm at Meshtastic's conservative chip-drive cap (19 dBm),
+// not the advertised PA output power.
+// =============================================================
+#pragma once
+
+inline const BoardConfig BOARD = {
+    .name        = "Station G2",
+    .fw_suffix   = "station_g2",
+    .mdns_prefix = "station-g2",
+
+    // SX1262 control + remapped SPI bus from Meshtastic station-common.
+    .pin_lora_nss  = 11,
+    .pin_lora_rst  = 21,
+    .pin_lora_busy = 47,
+    .pin_lora_dio1 = 48,
+    .pin_lora_sck  = 12,
+    .pin_lora_miso = 14,
+    .pin_lora_mosi = 13,
+
+    .rf_switch = {
+        .en_pin            = -1,
+        .en_low_hold_ms    = 0,
+        .rx_pin            = -1,
+        .tx_pin            = -1,
+        .dio2_as_rf_switch = true,
+    },
+
+    // Built-in OLED is SH1107. Disable until the display backend supports it.
+    .pin_i2c_sda      = -1,
+    .pin_i2c_scl      = -1,
+    .pin_i2c_oled_rst = -1,
+    .pin_vext_enable_low = -1,
+
+    .pin_user_button        = 38,
+    .user_button_active_low = true,
+
+    .max_tx_power_dbm = 19,
+
+    .use_dio3_tcxo = true,
+    .tcxo_voltage  = 1.8f,
+
+    .has_lora_radio = true,
+    .has_wifi       = true,
+    .has_network    = true,
+    .pin_protocol_uart_rx = -1,
+    .pin_protocol_uart_tx = -1,
+    .protocol_uart_baud   = 921600,
+    .ethernet = { .enabled = false },
+
+    // Station G2 does not need additional fixed FEM GPIO levels beyond the
+    // SX1262 DIO2/DIO3 radio controls above. Keep this explicit now that
+    // BoardConfig supports Heltec V4 static front-end GPIO setup.
+    .static_gpios = {},
+    .static_gpio_count = 0,
+};

--- a/firmware/include/oled_display.h
+++ b/firmware/include/oled_display.h
@@ -6,8 +6,16 @@
 
 #include <Wire.h>
 #include <Adafruit_GFX.h>
+#if defined(BOARD_STATION_G2)
+#include <Adafruit_SH110X.h>
+using OledDriver = Adafruit_SH1107;
+static constexpr uint16_t OLED_WHITE = SH110X_WHITE;
+#else
 #define SSD1306_NO_SPLASH
 #include <Adafruit_SSD1306.h>
+using OledDriver = Adafruit_SSD1306;
+static constexpr uint16_t OLED_WHITE = SSD1306_WHITE;
+#endif
 
 class OledDisplay {
 public:
@@ -69,6 +77,6 @@ public:
     void setStandby(bool standby);
 
 private:
-    Adafruit_SSD1306 *_display = nullptr;
+    OledDriver *_display = nullptr;
     bool _ready = false;
 };

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -175,6 +175,20 @@ build_flags =
     ${env.build_flags}
     -DBOARD_LILYGO_T3S3
 
+[env:station_g2]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+; B&Q Consulting Station G2 — ESP32-S3 WROOM-1 + SX1262 + PA/LNA.
+board_build.partitions = default_16MB.csv
+board_build.flash_size = 16MB
+board_upload.flash_size = 16MB
+upload_speed = 921600
+build_flags =
+    ${env.build_flags}
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HAS_PSRAM
+    -DBOARD_STATION_G2
+
 [env:heltec_t114]
 ; Heltec Mesh Node T114 (HT-n5262) — nRF52840 + SX1262, no Wi-Fi.
 ; Custom board JSON (firmware/boards/heltec_t114.json) + variant

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -183,6 +183,9 @@ board_build.partitions = default_16MB.csv
 board_build.flash_size = 16MB
 board_upload.flash_size = 16MB
 upload_speed = 921600
+lib_deps =
+    ${env.lib_deps}
+    adafruit/Adafruit SH110X@^2.1.13
 build_flags =
     ${env.build_flags}
     -DARDUINO_USB_CDC_ON_BOOT=1

--- a/firmware/src/oled_display.cpp
+++ b/firmware/src/oled_display.cpp
@@ -1,8 +1,7 @@
 // =============================================================
-// oled_display.cpp — SSD1306 status display
-// Same Adafruit_SSD1306 driver across every supported board; only
-// the I2C pins, optional VEXT rail and optional OLED reset line
-// vary, all sourced from board_config.h.
+// oled_display.cpp — I2C OLED status display
+// Heltec V3-class boards use SSD1306; Station G2 uses SH1107.
+// The board config provides I2C pins, optional VEXT rail, and reset line.
 // =============================================================
 #include "oled_display.h"
 #include "board_config.h"
@@ -40,20 +39,27 @@ void OledDisplay::begin() {
     // 3. Init I2C with the board's SDA/SCL pins
     Wire.begin(BOARD.pin_i2c_sda, BOARD.pin_i2c_scl);
 
-    // 4. Create Adafruit_SSD1306. Pass -1 when no RST pin is wired —
-    //    the library accepts that and skips its internal reset call.
-    _display = new Adafruit_SSD1306(128, 64, &Wire, BOARD.pin_i2c_oled_rst);
+    // 4. Create the board-specific OLED driver. Pass -1 when no RST pin is
+    //    wired — both Adafruit drivers accept that and skip reset.
+    _display = new OledDriver(128, 64, &Wire, BOARD.pin_i2c_oled_rst);
 
-    // 5. Start display — same call as MeshCore
+    // 5. Start display.
+#if defined(BOARD_STATION_G2)
+    if (_display->begin(DISPLAY_ADDRESS, true)) {
+        _ready = true;
+
+        _display->setContrast(0xFF);
+#else
     if (_display->begin(SSD1306_SWITCHCAPVCC, DISPLAY_ADDRESS, true, false)) {
         _ready = true;
 
         // 6. Max contrast/brightness
         _display->ssd1306_command(SSD1306_SETCONTRAST);
         _display->ssd1306_command(0xFF);
+#endif
 
         _display->clearDisplay();
-        _display->setTextColor(SSD1306_WHITE);
+        _display->setTextColor(OLED_WHITE);
         _display->setTextSize(1);
         _display->cp437(true);
         _display->display();
@@ -68,7 +74,7 @@ void OledDisplay::showSplash() {
     int16_t x = (128 - SPLASH_LOGO_W) / 2;
     int16_t y = 0;
     _display->drawBitmap(x, y, SPLASH_LOGO,
-                         SPLASH_LOGO_W, SPLASH_LOGO_H, SSD1306_WHITE);
+                         SPLASH_LOGO_W, SPLASH_LOGO_H, OLED_WHITE);
     _display->display();
 }
 
@@ -76,7 +82,7 @@ void OledDisplay::showBoot(const char* version) {
     if (!_ready) return;
     _display->clearDisplay();
     _display->setTextSize(1);
-    _display->setTextColor(SSD1306_WHITE);
+    _display->setTextColor(OLED_WHITE);
     _display->setCursor(0, 0);
     _display->println("LoRa Modem");
     _display->println(version);
@@ -94,7 +100,7 @@ void OledDisplay::showStatus(uint32_t rx, uint32_t tx,
     char buf[32];
     _display->clearDisplay();
     _display->setTextSize(1);
-    _display->setTextColor(SSD1306_WHITE);
+    _display->setTextColor(OLED_WHITE);
 
     // Header: firmware version (left) + right-aligned state tag.
     // Font is 6 px/char; state tag reserves 6 * strlen(state) px on the right.
@@ -114,7 +120,7 @@ void OledDisplay::showStatus(uint32_t rx, uint32_t tx,
         _display->setCursor(stateX, 0);
         _display->print(state);
     }
-    _display->drawFastHLine(0, 10, 128, SSD1306_WHITE);
+    _display->drawFastHLine(0, 10, 128, OLED_WHITE);
 
     // Line 1 — RX/TX counters
     _display->setCursor(0, 14);
@@ -144,7 +150,7 @@ void OledDisplay::showStatus(uint32_t rx, uint32_t tx,
 
     // Heartbeat dot, bottom-right
     static bool dot = false;
-    if (dot) _display->fillCircle(124, 60, 2, SSD1306_WHITE);
+    if (dot) _display->fillCircle(124, 60, 2, OLED_WHITE);
     dot = !dot;
 
     _display->display();
@@ -159,7 +165,7 @@ void OledDisplay::showRadioConfig(uint32_t freq_hz, uint32_t bandwidth_hz,
     char buf[32];
     _display->clearDisplay();
     _display->setTextSize(1);
-    _display->setTextColor(SSD1306_WHITE);
+    _display->setTextColor(OLED_WHITE);
 
     // Header: version + right-aligned state tag "RADIO" (5 chars → 30 px)
     const char* vs = (version && *version) ? version : "FW:?";
@@ -176,7 +182,7 @@ void OledDisplay::showRadioConfig(uint32_t freq_hz, uint32_t bandwidth_hz,
     _display->print(vbuf);
     _display->setCursor(stateX, 0);
     _display->print(stateTag);
-    _display->drawFastHLine(0, 10, 128, SSD1306_WHITE);
+    _display->drawFastHLine(0, 10, 128, OLED_WHITE);
 
     // Line 1 (y=14) — frequency in MHz with 3 decimals
     float freq_mhz = freq_hz / 1e6f;
@@ -207,7 +213,7 @@ void OledDisplay::showRadioConfig(uint32_t freq_hz, uint32_t bandwidth_hz,
 
     // Heartbeat dot, bottom-right
     static bool dot = false;
-    if (dot) _display->fillCircle(124, 60, 2, SSD1306_WHITE);
+    if (dot) _display->fillCircle(124, 60, 2, OLED_WHITE);
     dot = !dot;
 
     _display->display();
@@ -224,7 +230,7 @@ void OledDisplay::showDiagnostics(uint32_t uptime_sec,
     char buf[32];
     _display->clearDisplay();
     _display->setTextSize(1);
-    _display->setTextColor(SSD1306_WHITE);
+    _display->setTextColor(OLED_WHITE);
 
     // Header: version + right-aligned state tag "DIAG"
     const char* vs = (version && *version) ? version : "FW:?";
@@ -241,7 +247,7 @@ void OledDisplay::showDiagnostics(uint32_t uptime_sec,
     _display->print(vbuf);
     _display->setCursor(stateX, 0);
     _display->print(stateTag);
-    _display->drawFastHLine(0, 10, 128, SSD1306_WHITE);
+    _display->drawFastHLine(0, 10, 128, OLED_WHITE);
 
     // Line 1 (y=14) — uptime HH:MM:SS (rolls to DDd HH:MM after 100h)
     uint32_t days = uptime_sec / 86400;
@@ -290,7 +296,7 @@ void OledDisplay::showDiagnostics(uint32_t uptime_sec,
 
     // Heartbeat dot, bottom-right
     static bool dot = false;
-    if (dot) _display->fillCircle(124, 60, 2, SSD1306_WHITE);
+    if (dot) _display->fillCircle(124, 60, 2, OLED_WHITE);
     dot = !dot;
 
     _display->display();
@@ -300,7 +306,7 @@ void OledDisplay::showError(const char* msg) {
     if (!_ready) return;
     _display->clearDisplay();
     _display->setTextSize(1);
-    _display->setTextColor(SSD1306_WHITE);
+    _display->setTextColor(OLED_WHITE);
     _display->setCursor(0, 0);
     _display->println("ERROR:");
     _display->println(msg);
@@ -315,12 +321,20 @@ void OledDisplay::clear() {
 
 void OledDisplay::turnOff() {
     if (!_ready) return;
+#if defined(BOARD_STATION_G2)
+    _display->oled_command(SH110X_DISPLAYOFF);
+#else
     _display->ssd1306_command(SSD1306_DISPLAYOFF);
+#endif
 }
 
 void OledDisplay::turnOn() {
     if (!_ready) return;
+#if defined(BOARD_STATION_G2)
+    _display->oled_command(SH110X_DISPLAYON);
+#else
     _display->ssd1306_command(SSD1306_DISPLAYON);
+#endif
 }
 
 // ─── v0.7 cache hooks (originally for T114 TFT) ─────────────────────────

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -203,7 +203,12 @@ static bool attemptSTA() {
                   cfg.tcpToken.length() > 0 ? "token" : "open");
 
     WiFi.persistent(false);   // we manage persistence via Preferences
+#if defined(BOARD_STATION_G2)
+    // Station G2's high-power radio/TCP use case benefits from avoiding
+    // modem latency caused by Wi-Fi power-save sleep. Keep this scoped to
+    // Station G2 until other boards are explicitly validated with it.
     WiFi.setSleep(false);
+#endif
     WiFi.setAutoReconnect(true);
     WiFi.mode(WIFI_STA);
     WiFi.setHostname(effectiveHostname.c_str());

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -203,6 +203,7 @@ static bool attemptSTA() {
                   cfg.tcpToken.length() > 0 ? "token" : "open");
 
     WiFi.persistent(false);   // we manage persistence via Preferences
+    WiFi.setSleep(false);
     WiFi.setAutoReconnect(true);
     WiFi.mode(WIFI_STA);
     WiFi.setHostname(effectiveHostname.c_str());

--- a/firmware/tools/build_firmware_assets.py
+++ b/firmware/tools/build_firmware_assets.py
@@ -62,6 +62,11 @@ ENV_METADATA: dict[str, dict[str, str | bool]] = {
         "chip_family": "ESP32-S3",
         "web_manifest": True,
     },
+    "station_g2": {
+        "name": "B&Q Consulting Station G2 pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
     "esp32_p4_nano": {
         "name": "WaveShare ESP32-P4-Nano pyMC Modem",
         "chip_family": "ESP32-P4",
@@ -94,6 +99,7 @@ BOARD_HEADER_TO_ENV = {
     "firmware/include/boards/ikoka_stick.h": "ikoka_stick",
     "firmware/include/boards/xiao_wio_sx1262.h": "xiao_wio_sx1262",
     "firmware/include/boards/rak3112_wismesh.h": "rak3112_wismesh",
+    "firmware/include/boards/station_g2.h": "station_g2",
     "firmware/include/boards/esp32_p4_nano.h": "esp32_p4_nano",
     "firmware/include/boards/lilygo_t3s3.h": "lilygo_t3s3",
     "firmware/include/boards/heltec_t114.h": "heltec_t114",


### PR DESCRIPTION
Closes #7

Maintainer updates applied:
- Rebased Station G2 support onto current main after generated firmware assets landed.
- Preserved the current firmware asset flow: source/config PR only; generated `firmware/station_g2/` assets will be produced after merge to main.
- Added Station G2 metadata to the asset builder.
- Scoped `WiFi.setSleep(false)` to Station G2 only.
- Enabled the Station G2 SH1107 OLED path on SDA GPIO5 / SCL GPIO6 without changing existing SSD1306 boards.

Validation run locally:
- `python3 -m py_compile firmware/tools/build_firmware_assets.py`
- `python3 firmware/tools/build_firmware_assets.py --variant station_g2 --plan`
- `python3 firmware/tools/build_firmware_assets.py --variant auto --changed-from upstream/main --changed-to HEAD --plan`
- `pio run -e station_g2`
- `pio run -e heltec_v3`
- `python3 firmware/tools/build_firmware_assets.py --variant station_g2` plus `sha256sum -c firmware/station_g2/SHA256SUMS.txt` locally, then removed generated assets from the source PR.