### PR TITLE
Fix nRF52 board config initializers

### DIFF
--- a/firmware/include/boards/heltec_t114.h
+++ b/firmware/include/boards/heltec_t114.h
@@ -40,55 +40,56 @@
 //   (no external PA on this board variant).
 //
 // TX current at +20 dBm: ~157 mA @ 868 MHz. Sleep: 11 µA.
+//
+// Keep this aggregate positional rather than C++ designated-initialized:
+// the nRF52 toolchain uses GCC 7 and does not support non-trivial
+// designated initializers in C++.
 // =============================================================
 #pragma once
 
 inline const BoardConfig BOARD = {
-    .name        = "Heltec T114",
-    .fw_suffix   = "heltec_t114",
-    .mdns_prefix = "t114",   // unused — nRF52 has no Wi-Fi/mDNS
+    "Heltec T114",
+    "heltec_t114",
+    "t114",   // unused — nRF52 has no Wi-Fi/mDNS
 
     // SX1262 control pins.
-    .pin_lora_nss  = 24,
-    .pin_lora_rst  = 25,
-    .pin_lora_busy = 17,
-    .pin_lora_dio1 = 20,
-    .pin_lora_sck  = 19,
-    .pin_lora_miso = 23,
-    .pin_lora_mosi = 22,
+    24,  // pin_lora_nss
+    25,  // pin_lora_rst
+    17,  // pin_lora_busy
+    20,  // pin_lora_dio1
+    19,  // pin_lora_sck
+    23,  // pin_lora_miso
+    22,  // pin_lora_mosi
 
-    .rf_switch = {
-        .en_pin            = -1,
-        .en_low_hold_ms    = 0,
-        .rx_pin            = -1,
-        .tx_pin            = -1,
-        .dio2_as_rf_switch = true,   // SX1262 internal switch via DIO2
-    },
+    {-1, 0, -1, -1, true},  // SX1262 internal switch via DIO2
 
     // No I2C OLED on this board (TFT-LCD is on a separate SPI bus
     // and isn't wired up in iter 1 firmware).
-    .pin_i2c_sda      = -1,
-    .pin_i2c_scl      = -1,
-    .pin_i2c_oled_rst = -1,
-    .pin_vext_enable_low = -1,
+    -1,  // pin_i2c_sda
+    -1,  // pin_i2c_scl
+    -1,  // pin_i2c_oled_rst
+    -1,  // pin_vext_enable_low
 
-    .pin_user_button         = 42,
-    .user_button_active_low  = true,
+    42,    // pin_user_button
+    true,  // user_button_active_low
 
-    .max_tx_power_dbm = 21,           // datasheet 21 ±1 dBm
+    {-1, -1, true, 0.0f},  // no battery sense
 
-    .use_dio3_tcxo = true,
-    .tcxo_voltage  = 1.8f,
+    21,  // max_tx_power_dbm — datasheet 21 ±1 dBm
 
-    .has_lora_radio = true,
-    .has_wifi       = false,    // nRF52 has BT but not Wi-Fi
-    .has_network    = false,    // gates the entire WiFi+TCP+OTA stack
+    true,  // use_dio3_tcxo
+    1.8f,  // tcxo_voltage
+
+    true,   // has_lora_radio
+    false,  // has_wifi — nRF52 has BT but not Wi-Fi
+    false,  // has_network — gates the entire WiFi+TCP+OTA stack
 
     // Protocol on UART1 by default (sector-array controller wiring).
     // Flip to -1/-1 to talk only over USB-CDC.
-    .pin_protocol_uart_rx = 9,
-    .pin_protocol_uart_tx = 10,
-    .protocol_uart_baud   = 921600,
+    9,       // pin_protocol_uart_rx
+    10,      // pin_protocol_uart_tx
+    921600,  // protocol_uart_baud
 
-    .ethernet = { .enabled = false },
+    {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
+     {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 };

--- a/firmware/include/boards/xiao_nrf52_wio.h
+++ b/firmware/include/boards/xiao_nrf52_wio.h
@@ -32,58 +32,59 @@
 // rides on D5 (RXEN). Both must be wired in rf_switch{}.
 //
 // Max chip TX power on bare SX1262: 22 dBm. No external PA.
+//
+// Keep this aggregate positional rather than C++ designated-initialized:
+// the nRF52 toolchain uses GCC 7 and does not support non-trivial
+// designated initializers in C++.
 // =============================================================
 #pragma once
 
 inline const BoardConfig BOARD = {
-    .name        = "XIAO nRF52840 + Wio-SX1262",
-    .fw_suffix   = "xiao_nrf52_wio",
-    .mdns_prefix = "xiao-nrf",   // unused — nRF52 has no Wi-Fi/mDNS
+    "XIAO nRF52840 + Wio-SX1262",
+    "xiao_nrf52_wio",
+    "xiao-nrf",   // unused — nRF52 has no Wi-Fi/mDNS
 
     // SX1262 control pins (raw nRF52 GPIO via the identity variant).
-    .pin_lora_nss  = 4,    // D4
-    .pin_lora_rst  = 28,   // D2
-    .pin_lora_busy = 29,   // D3
-    .pin_lora_dio1 = 3,    // D1
+    4,   // pin_lora_nss  = D4
+    28,  // pin_lora_rst  = D2
+    29,  // pin_lora_busy = D3
+    3,   // pin_lora_dio1 = D1
     // SPI line numbers are informational on nRF52 (firmware calls
     // SPI.begin() without arguments — the variant.h PIN_SPI_* macros
     // pick the bus pins) but must be != -1 so main.cpp's SPI-init
     // branch fires.
-    .pin_lora_sck  = 45,   // D8  = P1.13
-    .pin_lora_miso = 46,   // D9  = P1.14
-    .pin_lora_mosi = 47,   // D10 = P1.15
+    45,  // pin_lora_sck  = D8  = P1.13
+    46,  // pin_lora_miso = D9  = P1.14
+    47,  // pin_lora_mosi = D10 = P1.15
 
-    .rf_switch = {
-        .en_pin            = -1,
-        .en_low_hold_ms    = 0,
-        .rx_pin            = 5,    // RXEN — LNA gate on D5 (P0.05)
-        .tx_pin            = -1,   // TX path driven internally via DIO2
-        .dio2_as_rf_switch = true,
-    },
+    {-1, 0, 5, -1, true},  // RXEN on D5/P0.05; TX via DIO2
 
     // No I2C peripheral on this kit. D4/D5 are claimed by NSS/RXEN,
     // so the silkscreen "SDA/SCL" labels are not honoured here.
-    .pin_i2c_sda      = -1,
-    .pin_i2c_scl      = -1,
-    .pin_i2c_oled_rst = -1,
-    .pin_vext_enable_low = -1,
+    -1,  // pin_i2c_sda
+    -1,  // pin_i2c_scl
+    -1,  // pin_i2c_oled_rst
+    -1,  // pin_vext_enable_low
 
-    .pin_user_button         = 18,   // P0.18 (Adafruit BTN0 / DFU)
-    .user_button_active_low  = true,
+    18,    // pin_user_button = P0.18 (Adafruit BTN0 / DFU)
+    true,  // user_button_active_low
 
-    .max_tx_power_dbm = 22,           // bare SX1262 chip ceiling
+    {-1, -1, true, 0.0f},  // no battery sense
 
-    .use_dio3_tcxo = true,
-    .tcxo_voltage  = 1.8f,            // 32 MHz TCXO on Wio-SX1262
+    22,  // max_tx_power_dbm — bare SX1262 chip ceiling
 
-    .has_lora_radio = true,
-    .has_wifi       = false,    // nRF52 has BLE but not Wi-Fi
-    .has_network    = false,    // no WiFi/TCP/OTA stack on this build
+    true,  // use_dio3_tcxo
+    1.8f,  // tcxo_voltage — 32 MHz TCXO on Wio-SX1262
+
+    true,   // has_lora_radio
+    false,  // has_wifi — nRF52 has BLE but not Wi-Fi
+    false,  // has_network — no WiFi/TCP/OTA stack on this build
 
     // No dedicated protocol UART — USB-CDC only.
-    .pin_protocol_uart_rx = -1,
-    .pin_protocol_uart_tx = -1,
-    .protocol_uart_baud   = 921600,
+    -1,      // pin_protocol_uart_rx
+    -1,      // pin_protocol_uart_tx
+    921600,  // protocol_uart_baud
 
-    .ethernet = { .enabled = false },
+    {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
+     {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 };


### PR DESCRIPTION
## Summary
- Convert the Heltec T114 and XIAO nRF52 Wio board configs from C++ designated initializers to positional aggregate initializers.
- Keep the same pin/policy values, including no battery sense and disabled Ethernet.
- This fixes the firmware asset workflow failure on the nRF52 GCC 7 toolchain, which does not support non-trivial designated initializers in C++.

## Verification
- pio run -d firmware -e heltec_t114
- pio run -d firmware -e xiao_nrf52_wio
- python3 firmware/tools/build_firmware_assets.py --variant heltec_v3,heltec_v4,ikoka_stick,xiao_wio_sx1262,rak3112_wismesh,esp32_p4_nano,lilygo_t3s3,heltec_t114,xiao_nrf52_wio --pio /home/yellowcooln/.local/bin/pio