### PR TITLE
ci: tolerate firmware asset PR permission limits

### DIFF
--- a/.github/workflows/build-firmware-assets.yml
+++ b/.github/workflows/build-firmware-assets.yml
@@ -233,6 +233,7 @@ jobs:
       - name: Create firmware asset update PR for protected main
         if: github.ref_name == 'main'
         uses: peter-evans/create-pull-request@v7
+        continue-on-error: true
         with:
           commit-message: 'firmware: update generated firmware assets [skip ci]'
           branch: automation/update-firmware-assets
@@ -306,6 +307,7 @@ jobs:
 
       - name: Create firmware asset update PR
         uses: peter-evans/create-pull-request@v7
+        continue-on-error: true
         with:
           commit-message: 'firmware: update generated firmware assets [skip ci]'
           branch: automation/update-firmware-assets


### PR DESCRIPTION
## Summary
- Keep the firmware asset workflow green when repository settings prevent GitHub Actions from creating pull requests.
- The workflow still builds assets and pushes the automation/update-firmware-assets branch; PR creation is allowed to fail without failing the whole job.

## Context
The run after merging PR #11 built the firmware assets and pushed automation/update-firmware-assets, then failed only because GitHub Actions is not permitted to create pull requests in this repository.

## Verification
- Parsed .github/workflows/build-firmware-assets.yml with Python yaml.safe_load.
- git diff --check