### PR TITLE
Add MeshSmith Photon-1W XIAO ESP32-C6 pyMC modem support with battery, Wi-Fi antenna, GPS, and diagnostics

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,10 +27,10 @@ The `esp32_p4_nano`, `station_g2`, and `photon_1w_xiao_esp32c6` envs use the
 (pinned in `platformio.ini`) for the Arduino-ESP32 3.x / ESP-IDF 5.x
 toolchain; first build will fetch the platform package once.
 
-### 1a. Prebuilt binaries (no PlatformIO)
+### 1a. Prebuilt ESP32-family binaries (no PlatformIO)
 
-`firmware/` ships per-board subdirectories with three flashable
-artefacts each:
+ESP32-family `firmware/<env>/` subdirectories ship three flashable artefacts
+each:
 
 | Path                              | Offset | Size  |
 |-----------------------------------|--------|-------|

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ your board:
 | Board | PlatformIO env | mDNS name | Network |
 |---|---|---|---|
 | Heltec WiFi LoRa 32 V3 | `heltec_v3` | `heltec-<mac3>.local` | Wi-Fi |
-| Ikoka Stick (XIAO ESP32-S3 + E22-P868M30S) | `ikoka_stick` | `ikoka-<mac3>.local` | Wi-Fi |
+| Ikoka Stick (XIAO ESP32-S3 + E22P868M30S) | `ikoka_stick` | `ikoka-<mac3>.local` | Wi-Fi |
 | LilyGO T-LoRa T3-S3 v1.2/v1.3 | `lilygo_t3s3` | `lilygo-t3s3-<mac3>.local` | Wi-Fi |
 | RAK3112 WisMesh | `rak3112_wismesh` | `rak3112-<mac3>.local` | Wi-Fi |
 | B&Q Consulting Station G2 | `station_g2` | `station-g2-<mac3>.local` | Wi-Fi |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,13 +10,19 @@ your board:
 | Board | PlatformIO env | mDNS name | Network |
 |---|---|---|---|
 | Heltec WiFi LoRa 32 V3 | `heltec_v3` | `heltec-<mac3>.local` | Wi-Fi |
+| Heltec WiFi LoRa 32 V4 | `heltec_v4` | `heltec-v4-<mac3>.local` | Wi-Fi |
+| Heltec Wireless Tracker V2 | `heltec_tracker_v2` | `tracker-v2-<mac3>.local` | Wi-Fi |
 | Ikoka Stick (XIAO ESP32-S3 + E22P868M30S) | `ikoka_stick` | `ikoka-<mac3>.local` | Wi-Fi |
+| Seeed XIAO Wio-SX1262 | `xiao_wio_sx1262` | `xiao-wio-<mac3>.local` | Wi-Fi |
+| MeshSmith Photon-1W ESP32-C6 | `photon_1w_xiao_esp32c6` | `photon-c6-<mac3>.local` | Wi-Fi |
 | LilyGO T-LoRa T3-S3 v1.2/v1.3 | `lilygo_t3s3` | `lilygo-t3s3-<mac3>.local` | Wi-Fi |
 | RAK3112 WisMesh | `rak3112_wismesh` | `rak3112-<mac3>.local` | Wi-Fi |
 | B&Q Consulting Station G2 | `station_g2` | `station-g2-<mac3>.local` | Wi-Fi |
 | WaveShare ESP32-P4-Nano (+ off-board E22) | `esp32_p4_nano` | `p4nano-<mac3>.local` | **Ethernet or Wi-Fi** (runtime auto-select; cable plugged → ETH, no link → WiFi fallback. Both at once is unstable with radio active — see README "Porting to another ESP32-P4 board") |
+| Heltec T114 | `heltec_t114` | n/a | none — USB-CDC + UART only |
+| Seeed XIAO nRF52840 + Wio-SX1262 | `xiao_nrf52_wio` | n/a | none — USB-CDC only |
 
-The `esp32_p4_nano` and `station_g2` envs use the
+The `esp32_p4_nano`, `station_g2`, and `photon_1w_xiao_esp32c6` envs use the
 [pioarduino fork](https://github.com/pioarduino/platform-espressif32)
 (pinned in `platformio.ini`) for the Arduino-ESP32 3.x / ESP-IDF 5.x
 toolchain; first build will fetch the platform package once.
@@ -32,15 +38,17 @@ artefacts each:
 | `firmware/<env>/partitions.bin`   | `0x8000`  | 3 kB   |
 | `firmware/<env>/firmware.bin`     | `0x10000` | ~830 kB|
 
-`<env>` is one of: `heltec_v3`, `ikoka_stick`, `lilygo_t3s3`,
-`rak3112_wismesh`, `esp32_p4_nano`, `station_g2`.
+`<env>` is one of: `heltec_v3`, `heltec_v4`, `heltec_tracker_v2`,
+`ikoka_stick`, `xiao_wio_sx1262`, `photon_1w_xiao_esp32c6`,
+`lilygo_t3s3`, `rak3112_wismesh`, `esp32_p4_nano`, or `station_g2`.
 
 ```bash
 pip install esptool
 
 # Full flash (fresh board, first install) — replace the ENV/CHIP pair
 # with the row that matches your board:
-ENV=heltec_v3      ; CHIP=esp32s3   # also for ikoka_stick / lilygo_t3s3 / rak3112_wismesh / station_g2
+ENV=heltec_v3      ; CHIP=esp32s3   # also for heltec_v4 / heltec_tracker_v2 / ikoka_stick / xiao_wio_sx1262 / lilygo_t3s3 / rak3112_wismesh / station_g2
+# ENV=photon_1w_xiao_esp32c6 ; CHIP=esp32c6
 # ENV=esp32_p4_nano ; CHIP=esp32p4
 
 esptool.py --chip $CHIP --port /dev/ttyUSB0 --baud 921600 write_flash \
@@ -93,8 +101,9 @@ curl -u admin:password -F firmware=@.pio/build/<env>/firmware.bin \
      http://<env-stem>-<mac3>.local/update
 ```
 
-Hostname stems are listed in §1 (e.g. `heltec`, `ikoka`,
-`lilygo-t3s3`, `rak3112`, `station-g2`, `p4nano`). The board reboots after upload.
+Hostname stems are listed in §1 (e.g. `heltec`, `heltec-v4`, `tracker-v2`,
+`ikoka`, `xiao-wio`, `photon-c6`, `lilygo-t3s3`, `rak3112`, `station-g2`,
+`p4nano`). The board reboots after upload.
 The HTTP OTA page uses Basic Auth with username `admin` and default
 password `password`; change it from the OTA page after first network boot.
 Rollback is **not** automatic on a broken image — keep the USB cable

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ documented in [INSTALL.md](INSTALL.md).
 The `Build Firmware Assets` GitHub workflow uses
 `firmware/tools/build_firmware_assets.py` to build PlatformIO envs and stage
 flasher-ready outputs in `firmware/<env>/`.  Pull requests do not build
-firmware.  Pushes to `main` build affected envs and commit updated
-`firmware/<env>/` binaries, manifests, and SHA256 sums back to `main` without
-uploading Actions artifacts.  Manual dispatch can build `auto`, `all`, or
-specific envs from any branch; manual runs upload Actions artifacts for review
-and only commit generated files when `commit_artifacts=true`.
+firmware.  Pushes to `main` build affected envs and open an asset-update PR
+containing updated `firmware/<env>/` binaries, manifests, and SHA256 sums
+without uploading Actions artifacts.  Manual dispatch can build `auto`, `all`,
+or specific envs from any branch; manual runs upload Actions artifacts for
+review and only commit generated files when `commit_artifacts=true`.
 
 ## Per-board pin map
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Ethernet) wired LAN.
 | **Heltec WiFi LoRa 32 V3**                                                                                  | ESP32-S3                     | bare SX1262                | Wi-Fi    |
 | **Heltec WiFi LoRa 32 V4**                                                                                  | ESP32-S3                     | SX1262 + PA/LNA FEM        | Wi-Fi    |
 | **Heltec Wireless Tracker V2**                                                                              | ESP32-S3                     | SX1262 + KCT8103L PA/FEM + TFT 160×80 | Wi-Fi |
-| **Ikoka Stick** ([ndoo/ikoka-stick-meshtastic-device](https://github.com/ndoo/ikoka-stick-meshtastic-device))| XIAO ESP32-S3                | Ebyte E22-P868M30S, +30 dBm | Wi-Fi   |
+| **Ikoka Stick** ([ndoo/ikoka-stick-meshtastic-device](https://github.com/ndoo/ikoka-stick-meshtastic-device))| XIAO ESP32-S3                | Ebyte E22P868M30S, +30 dBm | Wi-Fi   |
 | **Seeed XIAO Wio-SX1262**                                                                                   | XIAO ESP32-S3                | bare SX1262                | Wi-Fi    |
+| **MeshSmith Photon-1W ESP32-C6**                                                                            | XIAO ESP32-C6                | SX1262/E22P class 1 W      | Wi-Fi    |
 | **LilyGO T-LoRa T3-S3** v1.2/v1.3                                                                           | ESP32-S3                     | bare SX1262 + OLED         | Wi-Fi    |
 | **RAK3112 WisMesh**                                                                                         | ESP32-S3 (module)            | SX1262 in-module           | Wi-Fi    |
 | **B&Q Consulting Station G2**                                                                                | ESP32-S3                     | SX1262 + 35 dBm PA/LNA     | Wi-Fi    |
@@ -51,7 +52,7 @@ Raspberry Pi                                  pymc_modem modem
 
 ## Project layout
 
-- **`firmware/`** — PlatformIO tree, ten envs sharing one source.
+- **`firmware/`** — PlatformIO tree, twelve envs sharing one source.
   Each board lives in `include/boards/<env>.h`; `platformio.ini` picks
   one via `-DBOARD_<NAME>`. Prebuilt artifacts (ESP32: `bootloader.bin
   / partitions.bin / firmware.bin`; nRF52 T114: `firmware.hex` +
@@ -99,8 +100,9 @@ Per-board highlights (full pin numbers in the headers, mDNS prefix is
 - **Heltec V3** — onboard SSD1306, bare SX1262, max 22 dBm.
 - **Heltec V4** — onboard SSD1306, SX1262 + V4.x PA/LNA front-end, native USB-CDC, max 22 dBm SX1262 command power.
 - **Heltec Wireless Tracker V2** — ESP32-S3 + SX1262 + KCT8103L PA/FEM, ST7735 TFT 160×80, native USB-CDC, max 22 dBm SX1262 command power.
-- **Ikoka Stick** — XIAO ESP32-S3 + E22-P868M30S, EN-held + DIO2-as-RF-switch, max 30 dBm chip / +10 dB PA, external OLED.
+- **Ikoka Stick** — XIAO ESP32-S3 + E22P868M30S, EN-held + DIO2-as-RF-switch, max 30 dBm chip / +10 dB PA, external OLED.
 - **XIAO Wio-SX1262** — Seeed XIAO ESP32-S3 + bare SX1262, no OLED.
+- **MeshSmith Photon-1W ESP32-C6** — Seeed XIAO ESP32-C6 + Photon 1 W SX1262/E22P class front end, Photon XIAO pinout (D1 DIO1, D2 reset, D3 busy, D4 NSS, D5 RXEN, D8/D9/D10 SPI), Wi-Fi/TCP + AP provisioning + web UI/stats/OTA.
 - **LilyGO T3-S3** — bare SX1262 + onboard SSD1306, native USB-CDC.
 - **RAK3112 WisMesh** — SX1262 inside the RAK3112 module, no OLED.
 - **Station G2** — SX1262 + high-power PA/LNA, SH1107 display currently disabled, max SX1262 drive capped at 19 dBm.
@@ -108,7 +110,7 @@ Per-board highlights (full pin numbers in the headers, mDNS prefix is
 - **Heltec T114** — nRF52840 + bare SX1262 + ST7789 TFT 135×240, **no Wi-Fi/TCP/network OTA**; USB-CDC + UART transport only, OTA via Adafruit nRF52 DFU (USB) or in-app `CMD_OTA_*` over the protocol transport.
 - **Seeed XIAO nRF52840 + Wio-SX1262** (SKU 102010710) — XIAO nRF52840 + bare SX1262 on the Wio-SX1262 carrier, BLE 5.0 hardware unused, **no Wi-Fi/TCP/network OTA**, no display; native USB-CDC transport only, OTA via Adafruit nRF52 DFU (UF2 disk on double-click reset) or in-app `CMD_OTA_*`.
 
-### E22-P RF switch (Ikoka, P4-Nano + E22P)
+### E22P RF switch (Ikoka, P4-Nano + E22P)
 
 E22P truth table from the datasheet: `EN=1, T/R CTRL=1` → TX,
 `EN=1, T/R CTRL=0` → RX, `EN=0` → off. Firmware drives `EN` LOW for

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -183,6 +183,12 @@ struct BoardConfig {
     int8_t   pin_protocol_uart_tx;
     uint32_t protocol_uart_baud;
 
+    // Optional on-board GPS receiver. When both pins are >= 0 the firmware
+    // reads NMEA from this UART and exposes parsed data in /api/stats -> gps.
+    int8_t   pin_gps_uart_rx = -1;
+    int8_t   pin_gps_uart_tx = -1;
+    uint32_t gps_uart_baud = 9600;
+
     // ─── On-board Ethernet (RMII PHY) ───────────────────────
     // Set ethernet.enabled = true on boards with an internal EMAC +
     // external PHY (currently only ESP32-P4-Nano with IP101GRI). The

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -64,6 +64,12 @@ struct BatterySenseConfig {
     float  multiplier;          // raw pin voltage -> pack voltage
 };
 
+struct WifiAntennaSwitchConfig {
+    bool   enabled = false;      // true only on boards with a Wi-Fi RF switch
+    int8_t gpio3_pin = -1;       // ESP32-C6 Wi-Fi antenna select line 1
+    int8_t gpio14_pin = -1;      // ESP32-C6 Wi-Fi antenna select line 2
+};
+
 // ─── Full per-board config ──────────────────────────────────
 struct BoardConfig {
     const char* name;            // Display name on the OLED splash
@@ -147,6 +153,11 @@ struct BoardConfig {
     // entirely (Ethernet still comes up). Flip back to true once
     // esp_hosted is flashed on the C6.
     bool has_wifi;
+
+    // Optional Wi-Fi antenna switch. The ESP32-C6 Photon board uses two
+    // GPIOs to select the external Wi-Fi antenna path. Other boards leave
+    // this disabled so no extra settings or GPIO writes appear there.
+    WifiAntennaSwitchConfig wifi_antenna_switch;
 
     // Whole-board network capability gate. ESP32-S3 / ESP32-P4 boards
     // ship with the WifiManager + TCPServer + OTAManager + Ethernet

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -62,6 +62,8 @@ struct BatterySenseConfig {
     int8_t enable_pin;          // optional divider/ADC gate, -1 when always on
     bool   enable_active_high;
     float  multiplier;          // raw pin voltage -> pack voltage
+    uint8_t fuel_gauge_i2c_addr = 0;      // MAX17048-style fuel gauge, 0=none
+    uint8_t fuel_gauge_vcell_reg = 0x02;  // VCELL register (78.125 uV/LSB)
 };
 
 struct WifiAntennaSwitchConfig {

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -28,7 +28,7 @@
 //                     own RF switch is fully internal).
 //
 //   en_low_hold_ms    Boot-time hold duration for `en_pin` LOW. Ebyte
-//                     E22-P modules need ≥5000 ms for the LDOs and
+//                     E22P modules need ≥5000 ms for the LDOs and
 //                     PA bias to settle before EN goes HIGH; ignored
 //                     when en_pin == -1.
 //

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -229,10 +229,12 @@ extern const BoardConfig BOARD;
 #  include "boards/heltec_tracker_v2.h"
 #elif defined(BOARD_XIAO_WIO_SX1262)
 #  include "boards/xiao_wio_sx1262.h"
+#elif defined(BOARD_PHOTON_1W_XIAO_ESP32C6)
+#  include "boards/photon_1w_xiao_esp32c6.h"
 #elif defined(BOARD_XIAO_NRF52_WIO)
 #  include "boards/xiao_nrf52_wio.h"
 #elif defined(BOARD_STATION_G2)
 #  include "boards/station_g2.h"
 #else
-#  error "No board selected — add one of -DBOARD_HELTEC_V3 / -DBOARD_HELTEC_V4 / -DBOARD_IKOKA_STICK / -DBOARD_LILYGO_T3S3 / -DBOARD_RAK3112_WISMESH / -DBOARD_ESP32_P4_NANO / -DBOARD_HELTEC_T114 / -DBOARD_HELTEC_TRACKER_V2 / -DBOARD_XIAO_WIO_SX1262 / -DBOARD_XIAO_NRF52_WIO / -DBOARD_STATION_G2 to platformio.ini build_flags"
+#  error "No board selected — add one of -DBOARD_HELTEC_V3 / -DBOARD_HELTEC_V4 / -DBOARD_IKOKA_STICK / -DBOARD_LILYGO_T3S3 / -DBOARD_RAK3112_WISMESH / -DBOARD_ESP32_P4_NANO / -DBOARD_HELTEC_T114 / -DBOARD_HELTEC_TRACKER_V2 / -DBOARD_XIAO_WIO_SX1262 / -DBOARD_PHOTON_1W_XIAO_ESP32C6 / -DBOARD_XIAO_NRF52_WIO / -DBOARD_STATION_G2 to platformio.ini build_flags"
 #endif

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -64,6 +64,7 @@ struct BatterySenseConfig {
     float  multiplier;          // raw pin voltage -> pack voltage
     uint8_t fuel_gauge_i2c_addr = 0;      // MAX17048-style fuel gauge, 0=none
     uint8_t fuel_gauge_vcell_reg = 0x02;  // VCELL register (78.125 uV/LSB)
+    uint8_t fuel_gauge_crate_reg = 0;     // CRATE register, 0=not exposed
 };
 
 struct WifiAntennaSwitchConfig {

--- a/firmware/include/boards/esp32_p4_nano.h
+++ b/firmware/include/boards/esp32_p4_nano.h
@@ -21,7 +21,7 @@
 //     UART0 is on GPIO37 (TX) / GPIO38 (RX). Native USB-OTG goes
 //     to the USB type-A port (host mode), not used by the firmware.
 //   * No LoRa attached on day one (`has_lora_radio = false`). When
-//     an E22-P868M30S is wired later, flip the flag and uncomment
+//     an E22P868M30S is wired later, flip the flag and uncomment
 //     the pin block below — wiring matches §5.1 of the E22 datasheet.
 //
 // Pin allocation summary:
@@ -44,7 +44,7 @@ inline const BoardConfig BOARD = {
 
     // Future-LoRa pins are listed below for documentation, but
     // .has_lora_radio = false makes main.cpp skip every radio path.
-    // When the E22-P module is wired (per the connection table in
+    // When the E22P module is wired (per the connection table in
     // README/INSTALL), flip has_lora_radio to true and these pins
     // become live.
     .pin_lora_nss  = 45,
@@ -84,12 +84,12 @@ inline const BoardConfig BOARD = {
     .pin_user_button        = -1,
     .user_button_active_low = true,
 
-    .max_tx_power_dbm = 30,         // E22-P868M30S ceiling (when fitted)
+    .max_tx_power_dbm = 30,         // E22P868M30S ceiling (when fitted)
 
     .use_dio3_tcxo = true,
     .tcxo_voltage  = 1.8f,
 
-    .has_lora_radio = true,         // E22-P868M30S wired
+    .has_lora_radio = true,         // E22P868M30S wired
 
     // Both Wi-Fi and Ethernet are *capability* flags. main.cpp does
     // runtime selection in setup(): Ethernet is tried first, and if a

--- a/firmware/include/boards/heltec_t114.h
+++ b/firmware/include/boards/heltec_t114.h
@@ -99,6 +99,7 @@ inline const BoardConfig BOARD = {
 
     true,   // has_lora_radio
     false,  // has_wifi — nRF52 has BT but not Wi-Fi
+    {},     // wifi_antenna_switch
     false,  // has_network — gates the entire WiFi+TCP+OTA stack
 
     // Protocol on UART1 by default (sector-array controller wiring).

--- a/firmware/include/boards/ikoka_stick.h
+++ b/firmware/include/boards/ikoka_stick.h
@@ -1,8 +1,8 @@
 // =============================================================
-// boards/ikoka_stick.h — Ikoka Stick (XIAO ESP32-S3 + Ebyte E22-P868M30S)
+// boards/ikoka_stick.h — Ikoka Stick (XIAO ESP32-S3 + Ebyte E22P868M30S)
 //
 // Hardware ref: https://github.com/ndoo/ikoka-stick-meshtastic-device
-// LoRa front end: Ebyte E22-P868M30S (SX1262 + PA + LNA, 30 dBm / 1 W).
+// LoRa front end: Ebyte E22P868M30S (SX1262 + PA + LNA, 30 dBm / 1 W).
 //
 // E22 RF switch wiring on the Ikoka PCB (E22 datasheet §4.2):
 //   Pin 6 (RXEN, "EN" in truth table)  → MCU GPIO 6 — held HIGH for life,
@@ -35,7 +35,7 @@ inline const BoardConfig BOARD = {
 
     .rf_switch = {
         .en_pin            = 6,     // RXEN, GPIO6 / D5 — see header note
-        .en_low_hold_ms    = 5000,  // E22-P modules need ≥5 s LOW after boot
+        .en_low_hold_ms    = 5000,  // E22P modules need ≥5 s LOW after boot
         .rx_pin            = -1,
         .tx_pin            = -1,
         .dio2_as_rf_switch = true,  // DIO2 → TXEN trace on the Ikoka PCB
@@ -50,7 +50,7 @@ inline const BoardConfig BOARD = {
     .pin_user_button        = 1,    // D0
     .user_button_active_low = true,
 
-    // E22-P868M30S can deliver up to 30 dBm. Firmware caps requests
+    // E22P868M30S can deliver up to 30 dBm. Firmware caps requests
     // here; downstream (host config) is responsible for keeping inside
     // the regional ETSI / FCC limits for the chosen frequency band.
     .max_tx_power_dbm = 30,

--- a/firmware/include/boards/photon_1w_xiao_esp32c6.h
+++ b/firmware/include/boards/photon_1w_xiao_esp32c6.h
@@ -57,8 +57,10 @@ inline const BoardConfig BOARD = {
     .user_button_active_low = true,
 
     // Original MeshCore Photon firmware reads battery voltage from the
-    // MAX17048 fuel gauge on the Photon I2C bus (D4/D5), address 0x36,
-    // VCELL register 0x02.  No ADC divider is needed on the C6 module.
+    // MAX17048 fuel gauge on the Photon I2C bus (D4/D5), address 0x36.
+    // VCELL (0x02) reports voltage; CRATE (0x16) reports the signed battery
+    // charge/discharge rate in %/hr, useful for seeing solar charge input.
+    // No ADC divider is needed on the C6 module.
     .battery = {
         .pin = -1,
         .enable_pin = -1,
@@ -66,6 +68,7 @@ inline const BoardConfig BOARD = {
         .multiplier = 0.0f,
         .fuel_gauge_i2c_addr = 0x36,
         .fuel_gauge_vcell_reg = 0x02,
+        .fuel_gauge_crate_reg = 0x16,
     },
 
     .max_tx_power_dbm = 30,          // Photon 1W / E22P class front end

--- a/firmware/include/boards/photon_1w_xiao_esp32c6.h
+++ b/firmware/include/boards/photon_1w_xiao_esp32c6.h
@@ -1,0 +1,76 @@
+// =============================================================
+// boards/photon_1w_xiao_esp32c6.h — MeshSmith Photon 1W
+// Seeed XIAO ESP32-C6 + SX1262/E22P class 1W LoRa front end.
+//
+// Dedicated Photon C6 variant.  This keeps the generic XIAO ESP32-C6
+// and Wio-SX1262 variants untouched while matching the Photon nRF/XIAO
+// physical pinout used by the existing Photon hardware:
+//   D1  -> SX1262 DIO1 (IRQ)
+//   D2  -> SX1262 RESET
+//   D3  -> SX1262 BUSY
+//   D4  -> SX1262 NSS / CS
+//   D5  -> RXEN / LNA enable
+//   D6  -> I2C SCL
+//   D7  -> I2C SDA
+//   D8  -> SPI SCK
+//   D9  -> SPI MISO
+//   D10 -> SPI MOSI
+//
+// Arduino-ESP32 XIAO ESP32-C6 pin map:
+//   D1=GPIO1, D2=GPIO2, D3=GPIO21, D4=GPIO22, D5=GPIO23,
+//   D6=GPIO16, D7=GPIO17, D8=GPIO19, D9=GPIO20, D10=GPIO18.
+//
+// RF switch follows the Photon/Wio style: SX1262 DIO2 drives the TX
+// path, and D5/RXEN is toggled HIGH during RX by RadioLib.
+// =============================================================
+#pragma once
+
+inline const BoardConfig BOARD = {
+    .name        = "Photon 1W XIAO ESP32-C6",
+    .fw_suffix   = "photon_1w_xiao_esp32c6",
+    .mdns_prefix = "photon-c6",
+
+    .pin_lora_nss  = 22,   // D4
+    .pin_lora_rst  = 2,    // D2
+    .pin_lora_busy = 21,   // D3
+    .pin_lora_dio1 = 1,    // D1
+    .pin_lora_sck  = 19,   // D8
+    .pin_lora_miso = 20,   // D9
+    .pin_lora_mosi = 18,   // D10
+
+    .rf_switch = {
+        .en_pin            = -1,
+        .en_low_hold_ms    = 0,
+        .rx_pin            = 23,     // D5 / RXEN — RadioLib drives HIGH during RX
+        .tx_pin            = -1,     // TX path comes from SX1262 DIO2
+        .dio2_as_rf_switch = true,
+    },
+
+    // Photon pinout reserves XIAO D6/D7 for I2C.  There is no required
+    // onboard OLED for this modem, but these pins match the Photon header.
+    .pin_i2c_sda      = 17,   // D7
+    .pin_i2c_scl      = 16,   // D6
+    .pin_i2c_oled_rst = -1,
+    .pin_vext_enable_low = -1,
+
+    .pin_user_button        = 9,     // BOOT button on Seeed XIAO ESP32-C6
+    .user_button_active_low = true,
+
+    .max_tx_power_dbm = 30,          // Photon 1W / E22-P class front end
+
+    .use_dio3_tcxo = true,
+    .tcxo_voltage  = 1.8f,
+
+    .has_lora_radio = true,
+    .has_wifi       = true,
+    .has_network    = true,
+
+    // Protocol on USB-CDC by default; TCP is also available after Wi-Fi setup.
+    .pin_protocol_uart_rx = -1,
+    .pin_protocol_uart_tx = -1,
+    .protocol_uart_baud   = 921600,
+
+    .ethernet = { .enabled = false },
+    .static_gpios = {},
+    .static_gpio_count = 0,
+};

--- a/firmware/include/boards/photon_1w_xiao_esp32c6.h
+++ b/firmware/include/boards/photon_1w_xiao_esp32c6.h
@@ -56,6 +56,8 @@ inline const BoardConfig BOARD = {
     .pin_user_button        = 9,     // BOOT button on Seeed XIAO ESP32-C6
     .user_button_active_low = true,
 
+    .battery = { .pin = -1 },
+
     .max_tx_power_dbm = 30,          // Photon 1W / E22P class front end
 
     .use_dio3_tcxo = true,

--- a/firmware/include/boards/photon_1w_xiao_esp32c6.h
+++ b/firmware/include/boards/photon_1w_xiao_esp32c6.h
@@ -4,14 +4,13 @@
 //
 // Dedicated Photon C6 variant.  This keeps the generic XIAO ESP32-C6
 // and Wio-SX1262 variants untouched while matching the Photon nRF/XIAO
-// physical pinout used by the existing Photon hardware:
-//   D1  -> SX1262 DIO1 (IRQ)
-//   D2  -> SX1262 RESET
-//   D3  -> SX1262 BUSY
-//   D4  -> SX1262 NSS / CS
-//   D5  -> RXEN / LNA enable
-//   D6  -> I2C SCL
-//   D7  -> I2C SDA
+// physical pinout used by the existing Photon nRF hardware:
+//   D0  -> SX1262 DIO1 (IRQ)
+//   D1  -> SX1262 RESET
+//   D2  -> SX1262 BUSY
+//   D3  -> SX1262 NSS / CS
+//   D4  -> I2C SDA
+//   D5  -> I2C SCL
 //   D8  -> SPI SCK
 //   D9  -> SPI MISO
 //   D10 -> SPI MOSI
@@ -21,8 +20,8 @@
 //   D1=GPIO1, D2=GPIO2, D3=GPIO21, D4=GPIO22, D5=GPIO23,
 //   D6=GPIO16, D7=GPIO17, D8=GPIO19, D9=GPIO20, D10=GPIO18.
 //
-// RF switch follows the Photon/Wio style: SX1262 DIO2 drives the TX
-// path, and D5/RXEN is toggled HIGH during RX by RadioLib.
+// RF switch follows the Photon nRF variant: SX1262 DIO2 drives the RF
+// switch path; no MCU RXEN/TXEN GPIO is wired.
 // =============================================================
 #pragma once
 
@@ -31,10 +30,10 @@ inline const BoardConfig BOARD = {
     .fw_suffix   = "photon_1w_xiao_esp32c6",
     .mdns_prefix = "photon-c6",
 
-    .pin_lora_nss  = 22,   // D4
-    .pin_lora_rst  = 2,    // D2
-    .pin_lora_busy = 21,   // D3
-    .pin_lora_dio1 = 1,    // D1
+    .pin_lora_nss  = 21,   // D3
+    .pin_lora_rst  = 1,    // D1
+    .pin_lora_busy = 2,    // D2
+    .pin_lora_dio1 = 0,    // D0
     .pin_lora_sck  = 19,   // D8
     .pin_lora_miso = 20,   // D9
     .pin_lora_mosi = 18,   // D10
@@ -42,15 +41,15 @@ inline const BoardConfig BOARD = {
     .rf_switch = {
         .en_pin            = -1,
         .en_low_hold_ms    = 0,
-        .rx_pin            = 23,     // D5 / RXEN — RadioLib drives HIGH during RX
+        .rx_pin            = -1,
         .tx_pin            = -1,     // TX path comes from SX1262 DIO2
         .dio2_as_rf_switch = true,
     },
 
-    // Photon pinout reserves XIAO D6/D7 for I2C.  There is no required
+    // Photon pinout reserves XIAO D4/D5 for I2C.  There is no required
     // onboard OLED for this modem, but these pins match the Photon header.
-    .pin_i2c_sda      = 17,   // D7
-    .pin_i2c_scl      = 16,   // D6
+    .pin_i2c_sda      = 22,   // D4
+    .pin_i2c_scl      = 23,   // D5
     .pin_i2c_oled_rst = -1,
     .pin_vext_enable_low = -1,
 
@@ -63,6 +62,9 @@ inline const BoardConfig BOARD = {
 
     .use_dio3_tcxo = true,
     .tcxo_voltage  = 1.8f,
+
+    .sx126x_current_limit_ma = 140,
+    .sx126x_rx_boosted_gain = true,
 
     .has_lora_radio = true,
     .has_wifi       = true,

--- a/firmware/include/boards/photon_1w_xiao_esp32c6.h
+++ b/firmware/include/boards/photon_1w_xiao_esp32c6.h
@@ -56,7 +56,7 @@ inline const BoardConfig BOARD = {
     .pin_user_button        = 9,     // BOOT button on Seeed XIAO ESP32-C6
     .user_button_active_low = true,
 
-    .max_tx_power_dbm = 30,          // Photon 1W / E22-P class front end
+    .max_tx_power_dbm = 30,          // Photon 1W / E22P class front end
 
     .use_dio3_tcxo = true,
     .tcxo_voltage  = 1.8f,

--- a/firmware/include/boards/photon_1w_xiao_esp32c6.h
+++ b/firmware/include/boards/photon_1w_xiao_esp32c6.h
@@ -15,6 +15,7 @@
 //   D8  -> SPI SCK
 //   D9  -> SPI MISO
 //   D10 -> SPI MOSI
+//   GPIO3/GPIO14 -> ESP32-C6 Wi-Fi antenna switch
 //
 // Arduino-ESP32 XIAO ESP32-C6 pin map:
 //   D1=GPIO1, D2=GPIO2, D3=GPIO21, D4=GPIO22, D5=GPIO23,
@@ -65,6 +66,13 @@ inline const BoardConfig BOARD = {
 
     .has_lora_radio = true,
     .has_wifi       = true,
+
+    // External Wi-Fi antenna path: GPIO3 LOW and GPIO14 HIGH.
+    .wifi_antenna_switch = {
+        .enabled = true,
+        .gpio3_pin = 3,
+        .gpio14_pin = 14,
+    },
     .has_network    = true,
 
     // Protocol on USB-CDC by default; TCP is also available after Wi-Fi setup.

--- a/firmware/include/boards/photon_1w_xiao_esp32c6.h
+++ b/firmware/include/boards/photon_1w_xiao_esp32c6.h
@@ -95,6 +95,12 @@ inline const BoardConfig BOARD = {
     .pin_protocol_uart_tx = -1,
     .protocol_uart_baud   = 921600,
 
+    // Photon-1W GPS follows the original Photon nRF XIAO UART wiring:
+    // GPS TX -> XIAO D7 (MCU RX), GPS RX -> XIAO D6 (MCU TX).
+    .pin_gps_uart_rx = 17,   // D7 / GPIO17: ESP32-C6 RX from GPS TX
+    .pin_gps_uart_tx = 16,   // D6 / GPIO16: ESP32-C6 TX to GPS RX
+    .gps_uart_baud   = 115200,
+
     .ethernet = { .enabled = false },
     .static_gpios = {},
     .static_gpio_count = 0,

--- a/firmware/include/boards/photon_1w_xiao_esp32c6.h
+++ b/firmware/include/boards/photon_1w_xiao_esp32c6.h
@@ -56,7 +56,17 @@ inline const BoardConfig BOARD = {
     .pin_user_button        = 9,     // BOOT button on Seeed XIAO ESP32-C6
     .user_button_active_low = true,
 
-    .battery = { .pin = -1 },
+    // Original MeshCore Photon firmware reads battery voltage from the
+    // MAX17048 fuel gauge on the Photon I2C bus (D4/D5), address 0x36,
+    // VCELL register 0x02.  No ADC divider is needed on the C6 module.
+    .battery = {
+        .pin = -1,
+        .enable_pin = -1,
+        .enable_active_high = false,
+        .multiplier = 0.0f,
+        .fuel_gauge_i2c_addr = 0x36,
+        .fuel_gauge_vcell_reg = 0x02,
+    },
 
     .max_tx_power_dbm = 30,          // Photon 1W / E22P class front end
 

--- a/firmware/include/boards/xiao_nrf52_wio.h
+++ b/firmware/include/boards/xiao_nrf52_wio.h
@@ -95,6 +95,7 @@ inline const BoardConfig BOARD = {
 
     true,   // has_lora_radio
     false,  // has_wifi — nRF52 has BLE but not Wi-Fi
+    {},     // wifi_antenna_switch
     false,  // has_network — no WiFi/TCP/OTA stack on this build
 
     // No dedicated protocol UART — USB-CDC only.

--- a/firmware/include/gps_manager.h
+++ b/firmware/include/gps_manager.h
@@ -4,12 +4,23 @@
 
 namespace GPSManager {
 
+struct SatelliteInView {
+    String prn;
+    int16_t elevationDegrees = -1;
+    int16_t azimuthDegrees = -1;
+    float snrDb = -1.0f;
+    bool hasSnr = false;
+};
+
 struct Snapshot {
     bool enabled = false;
     bool seen = false;
     bool fixValid = false;
     uint8_t fixQuality = 0;
     uint8_t satellitesUsed = 0;
+    uint8_t satellitesInViewCount = 0;
+    uint8_t satellitesInViewStored = 0;
+    SatelliteInView satellitesInView[32];
     float latitude = 0.0f;
     float longitude = 0.0f;
     float altitudeM = 0.0f;

--- a/firmware/include/gps_manager.h
+++ b/firmware/include/gps_manager.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace GPSManager {
+
+struct Snapshot {
+    bool enabled = false;
+    bool seen = false;
+    bool fixValid = false;
+    uint8_t fixQuality = 0;
+    uint8_t satellitesUsed = 0;
+    float latitude = 0.0f;
+    float longitude = 0.0f;
+    float altitudeM = 0.0f;
+    bool hasAltitude = false;
+    float speedKmh = 0.0f;
+    bool hasSpeed = false;
+    float courseDegrees = 0.0f;
+    bool hasCourse = false;
+    String utcTime;
+    String date;
+    String datetimeUtc;
+    String lastSentenceType;
+    uint32_t lastUpdateMs = 0;
+    uint32_t validSentenceCount = 0;
+    uint32_t invalidChecksumCount = 0;
+    uint32_t rawByteCount = 0;
+    uint32_t configCommandCount = 0;
+};
+
+void begin();
+void loop();
+Snapshot snapshot();
+String buildJson();
+
+} // namespace GPSManager

--- a/firmware/include/gps_manager.h
+++ b/firmware/include/gps_manager.h
@@ -13,6 +13,7 @@ struct SatelliteInView {
 };
 
 struct Snapshot {
+    bool available = false;
     bool enabled = false;
     bool seen = false;
     bool fixValid = false;
@@ -40,7 +41,9 @@ struct Snapshot {
     uint32_t configCommandCount = 0;
 };
 
-void begin();
+bool hasGpsPins();
+void begin(bool enabled);
+void setEnabled(bool enabled);
 void loop();
 Snapshot snapshot();
 String buildJson();

--- a/firmware/include/runtime_stats.h
+++ b/firmware/include/runtime_stats.h
@@ -11,6 +11,9 @@ struct Snapshot {
     String firmwareVersion;
     bool radioStandby;
     bool autoCadEnabled;
+    bool hasBatteryChargeRatePctPerHour;
+    bool batteryChargeRatePctPerHourValid;
+    float batteryChargeRatePctPerHour;
 };
 
 Snapshot capture();

--- a/firmware/include/wifi_manager.h
+++ b/firmware/include/wifi_manager.h
@@ -29,6 +29,7 @@ struct Config {
     String    tcpToken;  // empty = no auth required
     uint16_t  tcpPort;   // default 5055
     bool      wifiExternalAntenna; // C6-only when BOARD enables antenna switch
+    bool      gpsEnabled; // default off; applies to any board with GPS UART pins
 };
 
 // Poll PRG button at boot; if held >= 3s, wipe NVS and reboot. Call from setup().

--- a/firmware/include/wifi_manager.h
+++ b/firmware/include/wifi_manager.h
@@ -28,6 +28,7 @@ struct Config {
     IPAddress dns2;
     String    tcpToken;  // empty = no auth required
     uint16_t  tcpPort;   // default 5055
+    bool      wifiExternalAntenna; // C6-only when BOARD enables antenna switch
 };
 
 // Poll PRG button at boot; if held >= 3s, wipe NVS and reboot. Call from setup().
@@ -51,6 +52,8 @@ const char* getIPString();    // dotted quad, "---" when offline
 const char* getHostname();    // configured hostname, or MAC-derived fallback
 bool        isSTAConnected();
 bool        isAPActive();
+bool        hasWifiAntennaSwitch();
+void        applyWifiAntennaSwitch();
 
 const Config& getConfig();
 void          saveConfig(const Config& cfg);

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -3,7 +3,7 @@
 ; Two boards share the same source tree; pick one per build:
 ;   pio run -e heltec_v3      → Heltec WiFi LoRa 32 V3 (bare SX1262)
 ;   pio run -e heltec_v4      → Heltec WiFi LoRa 32 V4 (SX1262 + FEM)
-;   pio run -e ikoka_stick    → XIAO ESP32-S3 + Ebyte E22-P868M30S
+;   pio run -e ikoka_stick    → XIAO ESP32-S3 + Ebyte E22P868M30S
 ; =============================================================
 
 [env]

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,6 +1,6 @@
 ; =============================================================
 ; pymc_modem LoRa Modem — Serial-to-SX1262 bridge for pymc_core
-; Two boards share the same source tree; pick one per build:
+; Supported boards share the same source tree; pick one env per build:
 ;   pio run -e heltec_v3      → Heltec WiFi LoRa 32 V3 (bare SX1262)
 ;   pio run -e heltec_v4      → Heltec WiFi LoRa 32 V4 (SX1262 + FEM)
 ;   pio run -e ikoka_stick    → XIAO ESP32-S3 + Ebyte E22P868M30S

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -121,6 +121,19 @@ build_flags =
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DBOARD_XIAO_WIO_SX1262
 
+[env:photon_1w_xiao_esp32c6]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
+board = seeed_xiao_esp32c6
+; MeshSmith Photon 1W pyMC modem: Seeed XIAO ESP32-C6 + Photon SX1262/E22P
+; front end using the same XIAO physical pinout as the Photon nRF hardware.
+; Native USB-CDC carries the pyMC binary protocol; Wi-Fi/TCP and OTA remain
+; available through the normal pyMC provisioning flow.
+board_build.partitions = min_spiffs.csv
+build_flags =
+    ${env.build_flags}
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_PHOTON_1W_XIAO_ESP32C6
+
 [env:rak3112_wismesh]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
 board = esp32-s3-devkitc-1

--- a/firmware/src/config_portal.cpp
+++ b/firmware/src/config_portal.cpp
@@ -109,7 +109,7 @@ static void handleRoot() {
     if (WifiManager::hasWifiAntennaSwitch()) {
         html += F("<label><input type='checkbox' name='wifi_ant_ext' value='1'");
         if (cfg.wifiExternalAntenna) html += F(" checked");
-        html += F("> Use external Wi-Fi antenna <span class='hint'>(ESP32-C6: GPIO3 low, GPIO14 high)</span></label>");
+        html += F("> Use external Wi-Fi antenna</label>");
     }
 
     html += F("<label><input type='checkbox' name='static' value='1'");

--- a/firmware/src/config_portal.cpp
+++ b/firmware/src/config_portal.cpp
@@ -106,6 +106,12 @@ static void handleRoot() {
     html += F("<label>Wi-Fi password</label>");
     html += "<input type='password' name='password' value='" + htmlEscape(cfg.password) + "'>";
 
+    if (WifiManager::hasWifiAntennaSwitch()) {
+        html += F("<label><input type='checkbox' name='wifi_ant_ext' value='1'");
+        if (cfg.wifiExternalAntenna) html += F(" checked");
+        html += F("> Use external Wi-Fi antenna <span class='hint'>(ESP32-C6: GPIO3 low, GPIO14 high)</span></label>");
+    }
+
     html += F("<label><input type='checkbox' name='static' value='1'");
     if (cfg.useStaticIP) html += F(" checked");
     html += F("> Use static IP (otherwise DHCP)</label>");
@@ -152,6 +158,9 @@ static void handleSave() {
     ssidSel.trim();
     newCfg.ssid        = ssidMan.length() > 0 ? ssidMan : ssidSel;
     newCfg.password    = server->arg("password");
+    newCfg.wifiExternalAntenna = WifiManager::hasWifiAntennaSwitch()
+                                    ? server->hasArg("wifi_ant_ext")
+                                    : false;
     newCfg.useStaticIP = server->hasArg("static");
     newCfg.staticIP    = parseIP(server->arg("ip"));
     newCfg.gateway     = parseIP(server->arg("gw"));

--- a/firmware/src/gps_manager.cpp
+++ b/firmware/src/gps_manager.cpp
@@ -53,7 +53,7 @@ static void scheduleAtgm336hConfig() {
 static void runAtgm336hConfig() {
     static const char* const configCommands[CONFIG_COMMAND_COUNT] = {
         "$PCAS02,1000*2E",              // 1 Hz fixes.
-        "$PCAS03,1,0,0,0,1,0,0,0*02",  // GGA + RMC only.
+        "$PCAS03,1,0,0,1,1,0,0,0*03",  // GGA + GSV + RMC.
     };
 
     if (nextConfigCommand >= CONFIG_COMMAND_COUNT) return;
@@ -194,6 +194,32 @@ static void parseRmc(const String& payload) {
     updateDatetime();
 }
 
+static void parseGsv(const String& payload) {
+    int messageNumber = field(payload, 2).toInt();
+    int satellitesInView = field(payload, 3).toInt();
+    if (satellitesInView >= 0) {
+        current.satellitesInViewCount = (uint8_t)max(0, min(255, satellitesInView));
+    }
+    if (messageNumber == 1) {
+        current.satellitesInViewStored = 0;
+    }
+
+    for (uint8_t idx = 4; idx < 20; idx += 4) {
+        String prn = field(payload, idx);
+        if (prn.length() == 0) continue;
+        if (current.satellitesInViewStored >= 32) break;
+
+        SatelliteInView& sat = current.satellitesInView[current.satellitesInViewStored++];
+        sat.prn = prn;
+        sat.elevationDegrees = (int16_t)field(payload, idx + 1).toInt();
+        sat.azimuthDegrees = (int16_t)field(payload, idx + 2).toInt();
+
+        String snr = field(payload, idx + 3);
+        sat.hasSnr = snr.length() > 0;
+        sat.snrDb = sat.hasSnr ? snr.toFloat() : -1.0f;
+    }
+}
+
 static void parseSentence(String sentence) {
     sentence.trim();
     if (sentence.length() == 0) return;
@@ -223,6 +249,8 @@ static void parseSentence(String sentence) {
 
     if (type == "GGA") {
         parseGga(payload);
+    } else if (type == "GSV") {
+        parseGsv(payload);
     } else if (type == "RMC") {
         parseRmc(payload);
     }
@@ -272,7 +300,7 @@ Snapshot snapshot() {
 String buildJson() {
     Snapshot snap = snapshot();
     String body;
-    body.reserve(512);
+    body.reserve(2048);
     body += F("{\"enabled\":");
     body += snap.enabled ? F("true") : F("false");
     body += F(",\"seen\":");
@@ -292,6 +320,23 @@ String buildJson() {
     body += F("},\"satellites\":{");
     body += F("\"used_count\":");
     body += String(snap.satellitesUsed);
+    body += F(",\"in_view_count\":");
+    body += String(snap.satellitesInViewCount);
+    body += F(",\"in_view\":[");
+    for (uint8_t i = 0; i < snap.satellitesInViewStored; ++i) {
+        const SatelliteInView& sat = snap.satellitesInView[i];
+        if (i > 0) body += ',';
+        body += F("{\"prn\":");
+        body += jsonQuote(sat.prn);
+        body += F(",\"elevation_degrees\":");
+        body += sat.elevationDegrees >= 0 ? String(sat.elevationDegrees) : String("null");
+        body += F(",\"azimuth_degrees\":");
+        body += sat.azimuthDegrees >= 0 ? String(sat.azimuthDegrees) : String("null");
+        body += F(",\"snr_db\":");
+        body += sat.hasSnr ? String(sat.snrDb, 1) : String("null");
+        body += F("}");
+    }
+    body += F("]");
     body += F("},\"time\":{");
     body += F("\"utc_time\":");
     body += snap.utcTime.length() ? jsonQuote(snap.utcTime) : String("null");

--- a/firmware/src/gps_manager.cpp
+++ b/firmware/src/gps_manager.cpp
@@ -40,8 +40,35 @@ static String jsonQuote(const String& value) {
     return String("\"") + jsonEscape(value) + "\"";
 }
 
-static bool hasGpsPins() {
+bool hasGpsPins() {
     return BOARD.pin_gps_uart_rx >= 0 && BOARD.pin_gps_uart_tx >= 0 && BOARD.gps_uart_baud > 0;
+}
+
+static void resetRuntimeFields() {
+    current.seen = false;
+    current.fixValid = false;
+    current.fixQuality = 0;
+    current.satellitesUsed = 0;
+    current.satellitesInViewCount = 0;
+    current.satellitesInViewStored = 0;
+    current.latitude = 0.0f;
+    current.longitude = 0.0f;
+    current.altitudeM = 0.0f;
+    current.hasAltitude = false;
+    current.speedKmh = 0.0f;
+    current.hasSpeed = false;
+    current.courseDegrees = 0.0f;
+    current.hasCourse = false;
+    current.utcTime = String();
+    current.date = String();
+    current.datetimeUtc = String();
+    current.lastSentenceType = String();
+    current.lastUpdateMs = 0;
+    current.validSentenceCount = 0;
+    current.invalidChecksumCount = 0;
+    current.rawByteCount = 0;
+    current.configCommandCount = 0;
+    line = String();
 }
 
 #ifdef ARDUINO_ARCH_ESP32
@@ -256,18 +283,47 @@ static void parseSentence(String sentence) {
     }
 }
 
-void begin() {
+void begin(bool enabled) {
     current = Snapshot{};
-    current.enabled = hasGpsPins();
+    current.available = hasGpsPins();
     line.reserve(128);
 #ifdef ARDUINO_ARCH_ESP32
-    if (!current.enabled) return;
-    gpsSerial.begin(BOARD.gps_uart_baud, SERIAL_8N1, BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx);
-    Serial.printf("[GPS] UART GPS enabled on RX=%d TX=%d baud=%lu\n",
-                  BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx,
-                  (unsigned long)BOARD.gps_uart_baud);
-    scheduleAtgm336hConfig();
+    setEnabled(enabled);
 #else
+    current.enabled = false;
+#endif
+}
+
+void setEnabled(bool enabled) {
+#ifdef ARDUINO_ARCH_ESP32
+    bool available = hasGpsPins();
+    if (!available) {
+        current.available = false;
+        current.enabled = false;
+        return;
+    }
+
+    current.available = true;
+    if (enabled == current.enabled) return;
+
+    if (enabled) {
+        resetRuntimeFields();
+        gpsSerial.begin(BOARD.gps_uart_baud, SERIAL_8N1, BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx);
+        current.enabled = true;
+        Serial.printf("[GPS] UART GPS enabled on RX=%d TX=%d baud=%lu\n",
+                      BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx,
+                      (unsigned long)BOARD.gps_uart_baud);
+        scheduleAtgm336hConfig();
+    } else {
+        gpsSerial.end();
+        current.enabled = false;
+        nextConfigCommand = CONFIG_COMMAND_COUNT;
+        resetRuntimeFields();
+        Serial.println("[GPS] UART GPS disabled");
+    }
+#else
+    (void)enabled;
+    current.available = false;
     current.enabled = false;
 #endif
 }
@@ -303,6 +359,8 @@ String buildJson() {
     body.reserve(2048);
     body += F("{\"enabled\":");
     body += snap.enabled ? F("true") : F("false");
+    body += F(",\"available\":");
+    body += snap.available ? F("true") : F("false");
     body += F(",\"seen\":");
     body += snap.seen ? F("true") : F("false");
     body += F(",\"fix\":{");

--- a/firmware/src/gps_manager.cpp
+++ b/firmware/src/gps_manager.cpp
@@ -1,0 +1,330 @@
+#include "gps_manager.h"
+
+#include "board_config.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+#include <HardwareSerial.h>
+#endif
+
+namespace GPSManager {
+
+static Snapshot current;
+static String line;
+static constexpr unsigned long CONFIG_SETTLE_MS = 250;
+static constexpr unsigned long COMMAND_DELAY_MS = 40;
+static constexpr size_t CONFIG_COMMAND_COUNT = 2;
+static unsigned long nextConfigCommandAtMs = 0;
+static size_t nextConfigCommand = CONFIG_COMMAND_COUNT;
+
+#ifdef ARDUINO_ARCH_ESP32
+static HardwareSerial& gpsSerial = Serial1;
+#endif
+
+static String jsonEscape(const String& value) {
+    String out;
+    out.reserve(value.length() + 8);
+    for (size_t i = 0; i < value.length(); ++i) {
+        switch (value[i]) {
+            case '\"': out += F("\\\""); break;
+            case '\\': out += F("\\\\"); break;
+            case '\n': out += F("\\n"); break;
+            case '\r': out += F("\\r"); break;
+            case '\t': out += F("\\t"); break;
+            default: out += value[i]; break;
+        }
+    }
+    return out;
+}
+
+static String jsonQuote(const String& value) {
+    return String("\"") + jsonEscape(value) + "\"";
+}
+
+static bool hasGpsPins() {
+    return BOARD.pin_gps_uart_rx >= 0 && BOARD.pin_gps_uart_tx >= 0 && BOARD.gps_uart_baud > 0;
+}
+
+#ifdef ARDUINO_ARCH_ESP32
+static void scheduleAtgm336hConfig() {
+    nextConfigCommand = 0;
+    nextConfigCommandAtMs = millis() + CONFIG_SETTLE_MS;
+}
+
+static void runAtgm336hConfig() {
+    static const char* const configCommands[CONFIG_COMMAND_COUNT] = {
+        "$PCAS02,1000*2E",              // 1 Hz fixes.
+        "$PCAS03,1,0,0,0,1,0,0,0*02",  // GGA + RMC only.
+    };
+
+    if (nextConfigCommand >= CONFIG_COMMAND_COUNT) return;
+    if ((long)(millis() - nextConfigCommandAtMs) < 0) return;
+
+    gpsSerial.print(configCommands[nextConfigCommand++]);
+    gpsSerial.print("\r\n");
+    current.configCommandCount++;
+    nextConfigCommandAtMs = millis() + COMMAND_DELAY_MS;
+}
+#endif
+
+static bool checksumOk(const String& sentence) {
+    int star = sentence.indexOf('*');
+    if (star < 0) return false;
+    if (star + 2 >= (int)sentence.length()) return false;
+
+    uint8_t sum = 0;
+    int start = sentence.startsWith("$") ? 1 : 0;
+    for (int i = start; i < star; ++i) {
+        sum ^= (uint8_t)sentence[i];
+    }
+    char expected[3] = { sentence[star + 1], sentence[star + 2], '\0' };
+    char* end = nullptr;
+    unsigned long parsed = strtoul(expected, &end, 16);
+    return end && *end == '\0' && parsed == sum;
+}
+
+static String field(const String& payload, uint8_t index) {
+    int start = 0;
+    for (uint8_t i = 0; i < index; ++i) {
+        start = payload.indexOf(',', start);
+        if (start < 0) return String();
+        ++start;
+    }
+    int end = payload.indexOf(',', start);
+    if (end < 0) end = payload.length();
+    return payload.substring(start, end);
+}
+
+static float parseCoordinate(const String& value, const String& hemi) {
+    if (value.length() < 4 || hemi.length() == 0) return 0.0f;
+    int dot = value.indexOf('.');
+    if (dot < 0) dot = value.length();
+    int degreeDigits = dot - 2;
+    if (degreeDigits <= 0) return 0.0f;
+    float degrees = value.substring(0, degreeDigits).toFloat();
+    float minutes = value.substring(degreeDigits).toFloat();
+    float out = degrees + minutes / 60.0f;
+    char h = hemi[0];
+    if (h == 'S' || h == 's' || h == 'W' || h == 'w') out *= -1.0f;
+    return out;
+}
+
+static String formatUtcTime(const String& raw) {
+    if (raw.length() < 6) return String();
+    String hh = raw.substring(0, 2);
+    String mm = raw.substring(2, 4);
+    String ss = raw.substring(4);
+    return hh + ":" + mm + ":" + ss + "Z";
+}
+
+static String formatDate(const String& raw) {
+    if (raw.length() != 6) return String();
+    int day = raw.substring(0, 2).toInt();
+    int month = raw.substring(2, 4).toInt();
+    int yy = raw.substring(4, 6).toInt();
+    int year = yy < 80 ? 2000 + yy : 1900 + yy;
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%04d-%02d-%02d", year, month, day);
+    return String(buf);
+}
+
+static void updateDatetime() {
+    if (current.date.length() == 0 || current.utcTime.length() == 0) return;
+    String time = current.utcTime;
+    if (time.endsWith("Z")) time.remove(time.length() - 1);
+    current.datetimeUtc = current.date + "T" + time + "+00:00";
+}
+
+static String sentenceType(const String& payload) {
+    String talkerType = field(payload, 0);
+    if (talkerType.length() >= 3) return talkerType.substring(talkerType.length() - 3);
+    return talkerType;
+}
+
+static void parseGga(const String& payload) {
+    String utc = field(payload, 1);
+    String lat = field(payload, 2);
+    String ns = field(payload, 3);
+    String lon = field(payload, 4);
+    String ew = field(payload, 5);
+    int quality = field(payload, 6).toInt();
+    int sats = field(payload, 7).toInt();
+    String altitude = field(payload, 9);
+
+    if (utc.length()) current.utcTime = formatUtcTime(utc);
+    current.fixQuality = (uint8_t)max(0, min(255, quality));
+    current.fixValid = quality > 0;
+    current.satellitesUsed = (uint8_t)max(0, min(255, sats));
+    if (lat.length() && lon.length()) {
+        current.latitude = parseCoordinate(lat, ns);
+        current.longitude = parseCoordinate(lon, ew);
+    }
+    if (altitude.length()) {
+        current.altitudeM = altitude.toFloat();
+        current.hasAltitude = true;
+    }
+    updateDatetime();
+}
+
+static void parseRmc(const String& payload) {
+    String utc = field(payload, 1);
+    String status = field(payload, 2);
+    String lat = field(payload, 3);
+    String ns = field(payload, 4);
+    String lon = field(payload, 5);
+    String ew = field(payload, 6);
+    String speedKnots = field(payload, 7);
+    String course = field(payload, 8);
+    String date = field(payload, 9);
+
+    if (utc.length()) current.utcTime = formatUtcTime(utc);
+    if (date.length()) current.date = formatDate(date);
+    current.fixValid = (status == "A" || status == "a");
+    if (lat.length() && lon.length()) {
+        current.latitude = parseCoordinate(lat, ns);
+        current.longitude = parseCoordinate(lon, ew);
+    }
+    if (speedKnots.length()) {
+        current.speedKmh = speedKnots.toFloat() * 1.852f;
+        current.hasSpeed = true;
+    }
+    if (course.length()) {
+        current.courseDegrees = course.toFloat();
+        current.hasCourse = true;
+    }
+    updateDatetime();
+}
+
+static void parseSentence(String sentence) {
+    sentence.trim();
+    if (sentence.length() == 0) return;
+    if (!sentence.startsWith("$")) return;
+    if (!checksumOk(sentence)) {
+        current.invalidChecksumCount++;
+        return;
+    }
+
+    int start = sentence.startsWith("$") ? 1 : 0;
+    int star = sentence.indexOf('*');
+    if (star < 0) star = sentence.length();
+    String payload = sentence.substring(start, star);
+    String type = sentenceType(payload);
+    if (type.length() == 0) return;
+    for (size_t i = 0; i < type.length(); ++i) {
+        char c = type[i];
+        if (!((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))) {
+            current.invalidChecksumCount++;
+            return;
+        }
+    }
+    current.lastSentenceType = type;
+    current.seen = true;
+    current.validSentenceCount++;
+    current.lastUpdateMs = millis();
+
+    if (type == "GGA") {
+        parseGga(payload);
+    } else if (type == "RMC") {
+        parseRmc(payload);
+    }
+}
+
+void begin() {
+    current = Snapshot{};
+    current.enabled = hasGpsPins();
+    line.reserve(128);
+#ifdef ARDUINO_ARCH_ESP32
+    if (!current.enabled) return;
+    gpsSerial.begin(BOARD.gps_uart_baud, SERIAL_8N1, BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx);
+    Serial.printf("[GPS] UART GPS enabled on RX=%d TX=%d baud=%lu\n",
+                  BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx,
+                  (unsigned long)BOARD.gps_uart_baud);
+    scheduleAtgm336hConfig();
+#else
+    current.enabled = false;
+#endif
+}
+
+void loop() {
+#ifdef ARDUINO_ARCH_ESP32
+    if (!current.enabled) return;
+    while (gpsSerial.available()) {
+        char c = (char)gpsSerial.read();
+        current.rawByteCount++;
+        if (c == '\n') {
+            parseSentence(line);
+            line = String();
+        } else if (c != '\r') {
+            if (line.length() < 128) {
+                line += c;
+            } else {
+                line = String();
+            }
+        }
+    }
+    runAtgm336hConfig();
+#endif
+}
+
+Snapshot snapshot() {
+    return current;
+}
+
+String buildJson() {
+    Snapshot snap = snapshot();
+    String body;
+    body.reserve(512);
+    body += F("{\"enabled\":");
+    body += snap.enabled ? F("true") : F("false");
+    body += F(",\"seen\":");
+    body += snap.seen ? F("true") : F("false");
+    body += F(",\"fix\":{");
+    body += F("\"valid\":");
+    body += snap.fixValid ? F("true") : F("false");
+    body += F(",\"quality\":");
+    body += String(snap.fixQuality);
+    body += F("},\"position\":{");
+    body += F("\"latitude\":");
+    body += snap.fixValid ? String(snap.latitude, 6) : String("null");
+    body += F(",\"longitude\":");
+    body += snap.fixValid ? String(snap.longitude, 6) : String("null");
+    body += F(",\"altitude_m\":");
+    body += snap.hasAltitude ? String(snap.altitudeM, 1) : String("null");
+    body += F("},\"satellites\":{");
+    body += F("\"used_count\":");
+    body += String(snap.satellitesUsed);
+    body += F("},\"time\":{");
+    body += F("\"utc_time\":");
+    body += snap.utcTime.length() ? jsonQuote(snap.utcTime) : String("null");
+    body += F(",\"date\":");
+    body += snap.date.length() ? jsonQuote(snap.date) : String("null");
+    body += F(",\"datetime_utc\":");
+    body += snap.datetimeUtc.length() ? jsonQuote(snap.datetimeUtc) : String("null");
+    body += F("},\"motion\":{");
+    body += F("\"speed_kmh\":");
+    body += snap.hasSpeed ? String(snap.speedKmh, 2) : String("null");
+    body += F(",\"course_degrees\":");
+    body += snap.hasCourse ? String(snap.courseDegrees, 2) : String("null");
+    body += F("},\"nmea\":{");
+    body += F("\"last_sentence_type\":");
+    body += snap.lastSentenceType.length() ? jsonQuote(snap.lastSentenceType) : String("null");
+    body += F(",\"valid_sentence_count\":");
+    body += String(snap.validSentenceCount);
+    body += F(",\"invalid_checksum_count\":");
+    body += String(snap.invalidChecksumCount);
+    body += F(",\"raw_byte_count\":");
+    body += String(snap.rawByteCount);
+    body += F(",\"config_command_count\":");
+    body += String(snap.configCommandCount);
+    body += F(",\"uart_rx_pin\":");
+    body += String(BOARD.pin_gps_uart_rx);
+    body += F(",\"uart_tx_pin\":");
+    body += String(BOARD.pin_gps_uart_tx);
+    body += F(",\"uart_baud\":");
+    body += String(BOARD.gps_uart_baud);
+    body += F(",\"age_ms\":");
+    body += snap.lastUpdateMs ? String((uint32_t)(millis() - snap.lastUpdateMs)) : String("null");
+    body += F("}}");
+    return body;
+}
+
+} // namespace GPSManager

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -44,6 +44,7 @@
 #  include "ota_manager.h"
 #  include "ethernet_manager.h"
 #  include "runtime_stats.h"
+#  include "gps_manager.h"
 #else
 // nRF52 (Heltec T114) build: the network / OLED / OTA managers are
 // excluded from the build via platformio.ini's build_src_filter.
@@ -1529,6 +1530,10 @@ void setup() {
     oledWakeUntil = millis() + OLED_WAKE_DURATION_MS;
     lastAutoCycleMs = millis();   // first auto-cycle fires SCREEN_AUTO_CYCLE_MS after splash
 
+#ifdef ARDUINO_ARCH_ESP32
+    GPSManager::begin();
+#endif
+
     // Arm the task watchdog LAST — everything above may legitimately take
     // many seconds (WiFi STA connect up to 30 s). From now on, any loop()
     // iteration that doesn't complete within LOOP_WDT_TIMEOUT_S triggers a
@@ -1615,6 +1620,9 @@ void loop() {
 
     if (tcpStarted) TCPServer::loop();
     if (otaStarted) OTAManager::loop();
+#ifdef ARDUINO_ARCH_ESP32
+    GPSManager::loop();
+#endif
 
     sampleNoiseFloor();
     if (BOARD.has_wifi) WifiManager::loop();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -70,6 +70,7 @@ namespace WifiManager {
         String   tcpToken;
         uint16_t tcpPort = 0;
         bool     wifiExternalAntenna = false;
+        bool     gpsEnabled = false;
     };
     inline void  checkResetButton()  {}
     inline void  begin()             {}
@@ -1531,7 +1532,7 @@ void setup() {
     lastAutoCycleMs = millis();   // first auto-cycle fires SCREEN_AUTO_CYCLE_MS after splash
 
 #ifdef ARDUINO_ARCH_ESP32
-    GPSManager::begin();
+    GPSManager::begin(WifiManager::getConfig().gpsEnabled);
 #endif
 
     // Arm the task watchdog LAST — everything above may legitimately take

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -161,8 +161,15 @@ public:
 };
 
 // SX1262 / E22P pin map comes from BOARD (see boards/<name>.h).
+#if defined(BOARD_PHOTON_1W_XIAO_ESP32C6)
+static SPIClass loraSpi(0);
+PymcSX1262 radio = new Module(BOARD.pin_lora_nss, BOARD.pin_lora_dio1,
+                              BOARD.pin_lora_rst, BOARD.pin_lora_busy,
+                              loraSpi);
+#else
 PymcSX1262 radio = new Module(BOARD.pin_lora_nss, BOARD.pin_lora_dio1,
                               BOARD.pin_lora_rst, BOARD.pin_lora_busy);
+#endif
 
 // Single instance regardless of build — on ESP32 this is the real
 // SSD1306 driver from oled_display.cpp; on nRF52 it's a no-op stub
@@ -1336,9 +1343,16 @@ void setup() {
         // transfer fails.
         if (BOARD.pin_lora_sck >= 0 || BOARD.pin_lora_miso >= 0 || BOARD.pin_lora_mosi >= 0) {
 #ifdef ARDUINO_ARCH_ESP32
+#if defined(BOARD_PHOTON_1W_XIAO_ESP32C6)
+            // Seeed XIAO ESP32-C6 Photon variant matches MeshCore's
+            // working C6 port, which uses SPIClass(0) for the LoRa bus.
+            loraSpi.begin(BOARD.pin_lora_sck, BOARD.pin_lora_miso,
+                          BOARD.pin_lora_mosi);
+#else
             // ESP32-S3/P4 GPIO matrix: rebind SPI to specific pins
             SPI.begin(BOARD.pin_lora_sck, BOARD.pin_lora_miso,
                       BOARD.pin_lora_mosi, BOARD.pin_lora_nss);
+#endif
 #else
             // nRF52 BSP: SPI peripheral has fixed pins on its
             // selected instance. The Heltec T114 variant.h ships

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -4,7 +4,7 @@
 //
 // Supported boards (selected at compile time via -DBOARD_<name>):
 //   * Heltec WiFi LoRa 32 V3 (ESP32-S3 + bare SX1262)
-//   * Ikoka Stick (XIAO ESP32-S3 + Ebyte E22-P868M30S)
+//   * Ikoka Stick (XIAO ESP32-S3 + Ebyte E22P868M30S)
 //
 // USB-CDC @ 921600 baud AND/OR TCP on the port configured via NVS.
 // OTA (ArduinoOTA + HTTP) is always-on whenever STA is connected.
@@ -157,7 +157,7 @@ public:
     }
 };
 
-// SX1262 / E22-P pin map comes from BOARD (see boards/<name>.h).
+// SX1262 / E22P pin map comes from BOARD (see boards/<name>.h).
 PymcSX1262 radio = new Module(BOARD.pin_lora_nss, BOARD.pin_lora_dio1,
                               BOARD.pin_lora_rst, BOARD.pin_lora_busy);
 
@@ -314,7 +314,7 @@ void onDio1Rise() {
 }
 
 // ─── E22 RF switch boot sequence ────────────────────────────
-// Some carrier boards (Ebyte E22-P series, see datasheet §4.2) need
+// Some carrier boards (Ebyte E22P series, see datasheet §4.2) need
 // their EN pin held LOW for several seconds at power-up so the LDOs
 // and PA bias can settle before RF traffic starts. After the hold,
 // EN goes HIGH and stays there forever — never toggled by the radio
@@ -636,7 +636,7 @@ bool applyConfig(const RadioConfig& cfg) {
     state = radio.setCodingRate(cfg.cr);
     if (state != RADIOLIB_ERR_NONE) return false;
 
-    // Hardware ceiling per board (E22-P868M30S = 30 dBm, bare SX1262 = 22).
+    // Hardware ceiling per board (E22P868M30S = 30 dBm, bare SX1262 = 22).
     int8_t pwr = cfg.power_dbm;
     if (pwr > BOARD.max_tx_power_dbm) pwr = BOARD.max_tx_power_dbm;
     state = radio.setOutputPower(pwr);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -67,6 +67,7 @@ namespace WifiManager {
         IPAddress dns2;
         String   tcpToken;
         uint16_t tcpPort = 0;
+        bool     wifiExternalAntenna = false;
     };
     inline void  checkResetButton()  {}
     inline void  begin()             {}
@@ -74,6 +75,8 @@ namespace WifiManager {
     inline void  loadConfigOnly()    {}
     inline bool  isSTAConnected()    { return false; }
     inline bool  isAPActive()        { return false; }
+    inline bool  hasWifiAntennaSwitch() { return false; }
+    inline void  applyWifiAntennaSwitch() {}
     inline const char* getSSID()     { return "---"; }
     inline const char* getIPString() { return "---"; }
     inline const char* getHostname() { return "---"; }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -274,9 +274,14 @@ static uint32_t lastUsbCmdMs = 0;
 
 #ifdef ARDUINO_ARCH_ESP32
 static bool readFuelGaugeRegister(uint8_t address, uint8_t reg, uint16_t& value) {
+    Wire.setTimeOut(50);
     Wire.beginTransmission(address);
     Wire.write(reg);
-    if (Wire.endTransmission(false) != 0) {
+    // Use a STOP between the register select and read.  The MAX17048 accepts
+    // this, and it avoids the ESP32-C6 Arduino core's repeated-start recovery
+    // path, which can wedge long enough to trip our loop watchdog when the
+    // Photon I2C bus/fuel gauge is absent or not pulled up.
+    if (Wire.endTransmission(true) != 0) {
         return false;
     }
     if (Wire.requestFrom(address, (uint8_t)2) != 2) {
@@ -323,6 +328,25 @@ static uint16_t readBatteryMilliVolts() {
     return (uint16_t)(packMv + 0.5f);
 }
 
+static bool readBatteryChargeRatePctPerHour(float& pctPerHour) {
+    if (BOARD.battery.fuel_gauge_i2c_addr == 0 ||
+        BOARD.battery.fuel_gauge_crate_reg == 0) {
+        return false;
+    }
+
+    uint16_t crate = 0;
+    if (!readFuelGaugeRegister(BOARD.battery.fuel_gauge_i2c_addr,
+                               BOARD.battery.fuel_gauge_crate_reg,
+                               crate)) {
+        return false;
+    }
+
+    // MAX17048 CRATE is signed, 0.208 %/hr per LSB. MeshCore surfaced this
+    // as current; on Photon it is actually the battery charge/discharge rate.
+    pctPerHour = (float)((int16_t)crate) * 0.208f;
+    return true;
+}
+
 namespace RuntimeStats {
 Snapshot capture() {
     Snapshot snap = {};
@@ -336,6 +360,12 @@ Snapshot capture() {
     snap.firmwareVersion = fwVersion;
     snap.radioStandby = radioStandby;
     snap.autoCadEnabled = autoCadEnabled;
+    snap.hasBatteryChargeRatePctPerHour = BOARD.battery.fuel_gauge_i2c_addr != 0 &&
+        BOARD.battery.fuel_gauge_crate_reg != 0;
+    if (snap.hasBatteryChargeRatePctPerHour) {
+        snap.batteryChargeRatePctPerHourValid = readBatteryChargeRatePctPerHour(
+            snap.batteryChargeRatePctPerHour);
+    }
     return snap;
 }
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -30,6 +30,7 @@
 // #ifdef below.
 #ifdef ARDUINO_ARCH_ESP32
 #  include <WiFi.h>
+#  include <Wire.h>
 #  include <esp_task_wdt.h>
 #  include <esp_system.h>
 #  include <esp_mac.h>
@@ -272,7 +273,33 @@ static uint32_t maxLoopUs = 0;
 static uint32_t lastUsbCmdMs = 0;
 
 #ifdef ARDUINO_ARCH_ESP32
+static bool readFuelGaugeRegister(uint8_t address, uint8_t reg, uint16_t& value) {
+    Wire.beginTransmission(address);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) {
+        return false;
+    }
+    if (Wire.requestFrom(address, (uint8_t)2) != 2) {
+        return false;
+    }
+    value = ((uint16_t)Wire.read() << 8) | Wire.read();
+    return true;
+}
+
 static uint16_t readBatteryMilliVolts() {
+    if (BOARD.battery.fuel_gauge_i2c_addr != 0) {
+        uint16_t vcell = 0;
+        if (readFuelGaugeRegister(BOARD.battery.fuel_gauge_i2c_addr,
+                                  BOARD.battery.fuel_gauge_vcell_reg,
+                                  vcell)) {
+            // MAX17048 VCELL uses 78.125 uV/LSB units, same conversion as
+            // the original MeshCore Photon firmware: vcell * 5 / 64 mV.
+            uint32_t mv = ((uint32_t)vcell * 5U) / 64U;
+            return mv > 65534U ? 65534U : (uint16_t)mv;
+        }
+        return 0xFFFF;
+    }
+
     if (BOARD.battery.pin < 0 || BOARD.battery.multiplier <= 0.0f) {
         return 0xFFFF;
     }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -727,11 +727,11 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
     // Any successfully-processed host frame counts toward OTA sanity.
     OTAManager::notifyValidFrame();
 
-    // Boards without a LoRa radio (ESP32-P4-Nano on day one) ack the
-    // non-radio commands (PING, GET_VERSION, GET_WIFI, AUTH, …) but
-    // refuse anything that would touch the SX1262. The host can still
+    // Boards without a LoRa radio, or boards where SX1262 init failed,
+    // ack the non-radio commands (PING, GET_VERSION, GET_WIFI, AUTH, …)
+    // but refuse anything that would touch the SX1262. The host can still
     // probe the modem and configure Wi-Fi via the existing flow.
-    if (!BOARD.has_lora_radio) {
+    if (!BOARD.has_lora_radio || !radioReady) {
         switch (cmd) {
         case CMD_TX_REQUEST:  case CMD_SET_CONFIG:  case CMD_GET_CONFIG:
         case CMD_STATUS_REQ:  case CMD_NOISE_REQ:   case CMD_CAD_REQUEST:
@@ -1358,12 +1358,9 @@ void setup() {
             oled.showError("SX1262 init fail!");
             while (Serial.availableForWrite() == 0) delay(10);
             sendError(ERR_RADIO_INIT, TransportSource::USB);
-            // Do not enter OTA loop without a working radio — this
-            // firmware would be rolled back automatically by the
-            // bootloader on reset.
-            while (true) delay(1000);
-        }
-
+            Serial.println("[BOOT] SX1262 init failed — continuing with Wi-Fi/config portal only");
+            radioReady = false;
+        } else {
         if (BOARD.use_dio3_tcxo) {
             state = radio.setTCXO(BOARD.tcxo_voltage);
             LOG_R_INFO("setTCXO(%.1f V) -> %d", BOARD.tcxo_voltage, state);
@@ -1386,6 +1383,7 @@ void setup() {
         }
 
         radioReady = true;
+        }
     } else {
         Serial.println("[BOOT] no LoRa radio on this board — running as Wi-Fi/Ethernet bridge only");
         radioReady = false;

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -98,6 +98,8 @@ static IPAddress parseIPArg(const String& s) {
 struct NetworkSnapshot {
     const char* iface = "Offline";
     bool live = false;
+    bool has_wifi_rssi = false;
+    int32_t wifi_rssi_dbm = 0;
     IPAddress ip;
     IPAddress subnet;
     IPAddress gateway;
@@ -125,6 +127,8 @@ static NetworkSnapshot getNetworkSnapshot() {
         snap.gateway = WiFi.gatewayIP();
         snap.dns1 = WiFi.dnsIP(0);
         snap.dns2 = WiFi.dnsIP(1);
+        snap.has_wifi_rssi = true;
+        snap.wifi_rssi_dbm = WiFi.RSSI();
         return snap;
     }
     if (WifiManager::isAPActive()) {
@@ -326,6 +330,10 @@ static String buildNetworkJson(const WifiManager::Config& cfg,
     body += ipJson(net.dns1);
     body += F(",\"dns2\":");
     body += ipJson(net.dns2);
+    if (net.has_wifi_rssi) {
+        body += F(",\"wifi_rssi_dbm\":");
+        body += String(net.wifi_rssi_dbm);
+    }
     body += F(",\"tcp_port\":");
     body += String(cfg.tcpPort);
     body += F(",\"pymc_token_set\":");
@@ -368,6 +376,10 @@ static String buildConfigJson(const WifiManager::Config& cfg) {
     body += ipJson(cfg.dns1);
     body += F(",\"dns2\":");
     body += ipJson(cfg.dns2);
+    if (WifiManager::hasWifiAntennaSwitch()) {
+        body += F(",\"wifi_external_antenna\":");
+        body += boolJson(cfg.wifiExternalAntenna);
+    }
     body += F("}");
     return body;
 }
@@ -465,6 +477,19 @@ static bool applyConfigPatch(JsonVariantConst root, WifiManager::Config& cfg, St
         cfg.useStaticIP = staticVal.as<bool>();
     }
 
+    JsonVariantConst antennaVal = obj["wifi_external_antenna"];
+    if (!antennaVal.isNull()) {
+        if (!WifiManager::hasWifiAntennaSwitch()) {
+            error = "wifi_external_antenna is not supported on this board.";
+            return false;
+        }
+        if (!antennaVal.is<bool>()) {
+            error = "wifi_external_antenna must be true or false.";
+            return false;
+        }
+        cfg.wifiExternalAntenna = antennaVal.as<bool>();
+    }
+
     JsonVariantConst networkVal = obj["network"];
     if (!networkVal.isNull()) {
         if (!networkVal.is<JsonObjectConst>()) {
@@ -487,6 +512,19 @@ static bool applyConfigPatch(JsonVariantConst root, WifiManager::Config& cfg, St
         if (!parseJsonIp(network["gateway"], cfg.gateway, "network.gateway", error)) return false;
         if (!parseJsonIp(network["dns1"], cfg.dns1, "network.dns1", error)) return false;
         if (!parseJsonIp(network["dns2"], cfg.dns2, "network.dns2", error)) return false;
+
+        JsonVariantConst antennaVal = network["wifi_external_antenna"];
+        if (!antennaVal.isNull()) {
+            if (!WifiManager::hasWifiAntennaSwitch()) {
+                error = "network.wifi_external_antenna is not supported on this board.";
+                return false;
+            }
+            if (!antennaVal.is<bool>()) {
+                error = "network.wifi_external_antenna must be true or false.";
+                return false;
+            }
+            cfg.wifiExternalAntenna = antennaVal.as<bool>();
+        }
     }
 
     if (cfg.useStaticIP &&
@@ -634,7 +672,13 @@ static void handleRoot() {
     body += "<div><label>DNS 1</label><input type='text' name='dns1' value='" + dns1Value + "' placeholder='1.1.1.1'></div>";
     body += "<div><label>DNS 2</label><input type='text' name='dns2' value='" + dns2Value + "' placeholder='8.8.8.8'></div>";
     body += "<div><label>Current source</label><div class='chip'>" + String(net.iface) + "</div></div>";
-    body += F("</div><button type='submit'>Save network settings</button></form></div></details>");
+    body += F("</div>");
+    if (WifiManager::hasWifiAntennaSwitch()) {
+        body += F("<div class='checkline'><input type='checkbox' id='wifi_ant_ext' name='wifi_ant_ext' value='1'");
+        if (cfg.wifiExternalAntenna) body += F(" checked");
+        body += F("><label for='wifi_ant_ext'>Use external Wi-Fi antenna <span class='m'>(ESP32-C6: GPIO3 low, GPIO14 high)</span></label></div>");
+    }
+    body += F("<button type='submit'>Save network settings</button></form></div></details>");
 
     body += F("<details><summary>pyMC Token</summary><div class='inside'>"
               "<p>This token must match the <code>token</code> value in pyMC so pyMC can connect to the radio.</p>"
@@ -698,6 +742,10 @@ static void handleStats() {
     body += "<div class='kv'><span class='k'>Current IP</span><span class='v'>" + currentIPString() + "</span></div>";
     body += "<div class='kv'><span class='k'>Connected client</span><span class='v'>" + (clientIP.length() > 0 ? clientIP : String("none")) + "</span></div>";
     body += "<div class='kv'><span class='k'>Interface</span><span class='v'>" + String(net.iface) + "</span></div>";
+    if (net.has_wifi_rssi) {
+        body += "<div class='kv'><span class='k'>Wi-Fi signal</span><span class='v'>" +
+                String(net.wifi_rssi_dbm) + " dBm</span></div>";
+    }
     body += "<div class='kv'><span class='k'>Uptime</span><span class='v'>" + formatUptime(snap.status.uptime_sec) + "</span></div>";
     if (snap.status.battery_mv != 0xFFFF) {
         body += "<div class='kv'><span class='k'>Battery</span><span class='v'>" +
@@ -730,6 +778,14 @@ static void handleStats() {
     body += F("<h3>Network</h3><div class='grid'>");
     body += "<div class='kv'><span class='k'>Mode</span><span class='v'>" + String(cfg.useStaticIP ? "Static" : "DHCP") + "</span></div>";
     body += "<div class='kv'><span class='k'>Port</span><span class='v'>" + String(cfg.tcpPort) + "</span></div>";
+    if (net.has_wifi_rssi) {
+        body += "<div class='kv'><span class='k'>Wi-Fi RSSI</span><span class='v'>" +
+                String(net.wifi_rssi_dbm) + " dBm</span></div>";
+    }
+    if (WifiManager::hasWifiAntennaSwitch()) {
+        body += "<div class='kv'><span class='k'>Wi-Fi antenna</span><span class='v'>" +
+                String(cfg.wifiExternalAntenna ? "External" : "Internal") + "</span></div>";
+    }
     body += "<div class='kv'><span class='k'>Gateway</span><span class='v'>" + ((uint32_t)net.gateway != 0 ? net.gateway.toString() : String("none")) + "</span></div>";
     body += "<div class='kv'><span class='k'>Subnet</span><span class='v'>" + ((uint32_t)net.subnet != 0 ? net.subnet.toString() : String("none")) + "</span></div>";
     body += "<div class='kv'><span class='k'>DNS 1</span><span class='v'>" + ((uint32_t)net.dns1 != 0 ? net.dns1.toString() : String("none")) + "</span></div>";
@@ -874,6 +930,11 @@ static void handleNetworkSave() {
     cfg.gateway     = parseIPArg(httpServer->arg("gw"));
     cfg.dns1        = parseIPArg(httpServer->arg("dns1"));
     cfg.dns2        = parseIPArg(httpServer->arg("dns2"));
+    if (WifiManager::hasWifiAntennaSwitch()) {
+        cfg.wifiExternalAntenna = httpServer->hasArg("wifi_ant_ext");
+    } else {
+        cfg.wifiExternalAntenna = false;
+    }
 
     if (cfg.useStaticIP) {
         if ((uint32_t)cfg.staticIP == 0 || (uint32_t)cfg.subnet == 0 || (uint32_t)cfg.gateway == 0) {

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -5,6 +5,7 @@
 #include "ota_manager.h"
 #include "board_config.h"
 #include "ethernet_manager.h"
+#include "gps_manager.h"
 #include "net_filter.h"
 #include "runtime_stats.h"
 #include "tcp_server.h"
@@ -396,7 +397,17 @@ static String buildStatsJson(const RuntimeStats::Snapshot& snap,
                              const String& clientIP) {
     String body;
     body.reserve(2048);
-    body += F("{\"system\":");
+    body += F("{\"battery_voltage_mv\":");
+    body += snap.status.battery_mv != 0xFFFF ? String(snap.status.battery_mv) : String("null");
+    body += F(",\"battery_voltage_v\":");
+    body += snap.status.battery_mv != 0xFFFF ? String(snap.status.battery_mv / 1000.0f, 3) : String("null");
+    if (snap.hasBatteryChargeRatePctPerHour) {
+        body += F(",\"solar_charge_rate_percent_per_hour\":");
+        body += snap.batteryChargeRatePctPerHourValid
+                    ? String(snap.batteryChargeRatePctPerHour, 3)
+                    : String("null");
+    }
+    body += F(",\"system\":");
     body += buildSystemJson(snap, net, clientIP);
     body += F(",\"radio\":");
     body += buildRadioJson(snap);
@@ -404,6 +415,8 @@ static String buildStatsJson(const RuntimeStats::Snapshot& snap,
     body += buildCountersJson(snap);
     body += F(",\"network\":");
     body += buildNetworkJson(cfg, net);
+    body += F(",\"gps\":");
+    body += GPSManager::buildJson();
     body += F("}");
     return body;
 }
@@ -723,6 +736,7 @@ static void handleStats() {
     const auto& cfg = WifiManager::getConfig();
     RuntimeStats::Snapshot snap = RuntimeStats::capture();
     NetworkSnapshot net = getNetworkSnapshot();
+    GPSManager::Snapshot gps = GPSManager::snapshot();
     String clientIP = TCPServer::getClientIP();
     String body;
     body.reserve(6144);
@@ -762,6 +776,16 @@ static void handleStats() {
                 (snap.batteryChargeRatePctPerHourValid
                     ? String(snap.batteryChargeRatePctPerHour, 3) + " %/hr"
                     : String("unknown")) + "</span></div>";
+    }
+    if (gps.enabled) {
+        body += "<div class='kv'><span class='k'>GPS fix</span><span class='v'>" +
+                String(gps.fixValid ? "valid" : (gps.seen ? "no fix" : "waiting")) +
+                "</span></div>";
+        if (gps.fixValid) {
+            body += "<div class='kv'><span class='k'>GPS location</span><span class='v'>" +
+                    String(gps.latitude, 6) + ", " + String(gps.longitude, 6) +
+                    "</span></div>";
+        }
     }
     body += "</div></div>";
 
@@ -850,6 +874,12 @@ static void handleApiNetwork() {
     if (!checkAuth()) return;
 
     sendJson(200, buildNetworkJson(WifiManager::getConfig(), getNetworkSnapshot()));
+}
+
+static void handleApiGps() {
+    if (!checkAuth()) return;
+
+    sendJson(200, GPSManager::buildJson());
 }
 
 static void handleApiStats() {
@@ -1138,6 +1168,7 @@ void begin(const String& hn, const String& tk) {
     httpServer->on("/api/system", HTTP_GET, handleApiSystem);
     httpServer->on("/api/radio", HTTP_GET, handleApiRadio);
     httpServer->on("/api/network", HTTP_GET, handleApiNetwork);
+    httpServer->on("/api/gps", HTTP_GET, handleApiGps);
     httpServer->on("/api/stats", HTTP_GET, handleApiStats);
     httpServer->on("/api/config", HTTP_GET, handleApiConfigGet);
     httpServer->on("/api/config", HTTP_POST, handleApiConfigPost);

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -252,6 +252,12 @@ static String buildSystemJson(const RuntimeStats::Snapshot& snap,
     body += snap.status.battery_mv != 0xFFFF ? String(snap.status.battery_mv) : String("null");
     body += F(",\"battery_voltage_v\":");
     body += snap.status.battery_mv != 0xFFFF ? String(snap.status.battery_mv / 1000.0f, 3) : String("null");
+    if (snap.hasBatteryChargeRatePctPerHour) {
+        body += F(",\"battery_charge_rate_pct_per_hour\":");
+        body += snap.batteryChargeRatePctPerHourValid
+                    ? String(snap.batteryChargeRatePctPerHour, 3)
+                    : String("null");
+    }
     body += F("}");
     return body;
 }
@@ -751,6 +757,12 @@ static void handleStats() {
         body += "<div class='kv'><span class='k'>Battery</span><span class='v'>" +
                 String(snap.status.battery_mv / 1000.0f, 3) + " V</span></div>";
     }
+    if (snap.hasBatteryChargeRatePctPerHour) {
+        body += "<div class='kv'><span class='k'>Battery charge rate</span><span class='v'>" +
+                (snap.batteryChargeRatePctPerHourValid
+                    ? String(snap.batteryChargeRatePctPerHour, 3) + " %/hr"
+                    : String("unknown")) + "</span></div>";
+    }
     body += "</div></div>";
 
     body += F("<h3>Radio</h3><div class='grid'>");
@@ -806,6 +818,12 @@ static void handleApiTemp() {
     body += snap.status.battery_mv != 0xFFFF ? String(snap.status.battery_mv) : String("null");
     body += F(",\"battery_voltage_v\":");
     body += snap.status.battery_mv != 0xFFFF ? String(snap.status.battery_mv / 1000.0f, 3) : String("null");
+    if (snap.hasBatteryChargeRatePctPerHour) {
+        body += F(",\"battery_charge_rate_pct_per_hour\":");
+        body += snap.batteryChargeRatePctPerHourValid
+                    ? String(snap.batteryChargeRatePctPerHour, 3)
+                    : String("null");
+    }
     body += F(",\"firmware\":\"");
     body += snap.firmwareVersion;
     body += F("\",\"hostname\":\"");

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -676,7 +676,7 @@ static void handleRoot() {
     if (WifiManager::hasWifiAntennaSwitch()) {
         body += F("<div class='checkline'><input type='checkbox' id='wifi_ant_ext' name='wifi_ant_ext' value='1'");
         if (cfg.wifiExternalAntenna) body += F(" checked");
-        body += F("><label for='wifi_ant_ext'>Use external Wi-Fi antenna <span class='m'>(ESP32-C6: GPIO3 low, GPIO14 high)</span></label></div>");
+        body += F("><label for='wifi_ant_ext'>Use external Wi-Fi antenna</label></div>");
     }
     body += F("<button type='submit'>Save network settings</button></form></div></details>");
 

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -387,6 +387,10 @@ static String buildConfigJson(const WifiManager::Config& cfg) {
         body += F(",\"wifi_external_antenna\":");
         body += boolJson(cfg.wifiExternalAntenna);
     }
+    body += F(",\"gps_enabled\":");
+    body += boolJson(cfg.gpsEnabled);
+    body += F(",\"gps_available\":");
+    body += boolJson(GPSManager::hasGpsPins());
     body += F("}");
     return body;
 }
@@ -507,6 +511,19 @@ static bool applyConfigPatch(JsonVariantConst root, WifiManager::Config& cfg, St
             return false;
         }
         cfg.wifiExternalAntenna = antennaVal.as<bool>();
+    }
+
+    JsonVariantConst gpsVal = obj["gps_enabled"];
+    if (!gpsVal.isNull()) {
+        if (!GPSManager::hasGpsPins()) {
+            error = "gps_enabled is not supported on this board.";
+            return false;
+        }
+        if (!gpsVal.is<bool>()) {
+            error = "gps_enabled must be true or false.";
+            return false;
+        }
+        cfg.gpsEnabled = gpsVal.as<bool>();
     }
 
     JsonVariantConst networkVal = obj["network"];
@@ -698,6 +715,17 @@ static void handleRoot() {
         body += F("><label for='wifi_ant_ext'>Use external Wi-Fi antenna</label></div>");
     }
     body += F("<button type='submit'>Save network settings</button></form></div></details>");
+
+    if (GPSManager::hasGpsPins()) {
+        body += F("<details open><summary>GPS</summary><div class='inside'>"
+                  "<p>Turn the onboard GPS receiver interface on only when location data is needed. Default is off to save battery.</p>"
+                  "<form method='POST' action='/gps'>"
+                  "<div class='checkline'><input type='checkbox' id='gps_enabled' name='gps_enabled' value='1'");
+        if (cfg.gpsEnabled) body += F(" checked");
+        body += F("><label for='gps_enabled'>Enable GPS</label></div>"
+                  "<button type='submit'>Save GPS setting</button>"
+                  "</form><p class='m'>Applies immediately and persists across reboots.</p></div></details>");
+    }
 
     body += F("<details><summary>pyMC Token</summary><div class='inside'>"
               "<p>This token must match the <code>token</code> value in pyMC so pyMC can connect to the radio.</p>"
@@ -1007,6 +1035,30 @@ static void handleNetworkSave() {
     ESP.restart();
 }
 
+static void handleGpsSave() {
+    if (!checkAuth()) return;
+
+    if (!GPSManager::hasGpsPins()) {
+        httpServer->send(400, "text/plain", "GPS is not supported on this board.\n");
+        return;
+    }
+
+    WifiManager::Config cfg = WifiManager::getConfig();
+    cfg.gpsEnabled = httpServer->hasArg("gps_enabled");
+    WifiManager::saveConfig(cfg);
+    GPSManager::setEnabled(cfg.gpsEnabled);
+
+    Serial.printf("[OTA] GPS %s by %s\n",
+                  cfg.gpsEnabled ? "enabled" : "disabled",
+                  httpServer->client().remoteIP().toString().c_str());
+
+    sendSimplePage(cfg.gpsEnabled ? F("GPS enabled") : F("GPS disabled"),
+                   cfg.gpsEnabled ? F("GPS enabled") : F("GPS disabled"),
+                   cfg.gpsEnabled
+                       ? F("The GPS UART is enabled. Fix data may take a moment to appear.")
+                       : F("The GPS UART is disabled and the setting has been saved."));
+}
+
 static void handleTokenSave() {
     if (!checkAuth()) return;
 
@@ -1175,6 +1227,7 @@ void begin(const String& hn, const String& tk) {
     httpServer->on("/api/reboot", HTTP_POST, handleApiReboot);
     httpServer->on("/hostname", HTTP_POST, handleHostnameSave);
     httpServer->on("/network", HTTP_POST, handleNetworkSave);
+    httpServer->on("/gps",     HTTP_POST, handleGpsSave);
     httpServer->on("/token",  HTTP_POST, handleTokenSave);
     httpServer->on("/auth",   HTTP_POST, handleAuthSave);
     httpServer->on("/reboot", HTTP_POST, handleReboot);

--- a/firmware/src/tcp_server.cpp
+++ b/firmware/src/tcp_server.cpp
@@ -21,6 +21,8 @@ static WiFiClient  client;
 static String      requiredToken  = "";
 static bool        authenticated  = false;
 static FrameParser parser;
+static uint32_t    acceptedCount  = 0;
+static uint32_t    frameCount     = 0;
 
 static bool requiresAuth() { return requiredToken.length() > 0; }
 
@@ -56,21 +58,33 @@ static void sendErrorToClient(uint8_t err) {
 }
 
 static void disconnectClient() {
-    if (client) client.stop();
+    if (client) {
+        Serial.printf("[TCP] disconnect client %s auth=%u frames=%lu\n",
+                      client.remoteIP().toString().c_str(),
+                      authenticated ? 1U : 0U,
+                      (unsigned long)frameCount);
+        client.stop();
+    }
     authenticated = false;
+    frameCount = 0;
     parser.reset();
 }
 
 static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len, TransportSource src) {
     (void)src;  // always TCP here
+    frameCount++;
+    Serial.printf("[TCP] frame cmd=0x%02X len=%u auth=%u\n",
+                  cmd, (unsigned)len, authenticated ? 1U : 0U);
 
     if (requiresAuth() && !authenticated) {
         if (cmd == CMD_AUTH) {
             if (len == requiredToken.length() &&
                 memcmp(payload, requiredToken.c_str(), len) == 0) {
                 authenticated = true;
+                Serial.println("[TCP] auth OK");
                 sendToClient(CMD_AUTH_OK, nullptr, 0);
             } else {
+                Serial.println("[TCP] auth rejected");
                 sendErrorToClient(ERR_UNAUTHORIZED);
                 delay(5);
                 disconnectClient();
@@ -95,6 +109,7 @@ static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len, Transpo
 
 static void onFrameErr(uint8_t err_code, TransportSource src) {
     (void)src;
+    Serial.printf("[TCP] frame parse error 0x%02X\n", err_code);
     noteTransportFrameError(err_code);
     sendErrorToClient(err_code);
 }
@@ -142,6 +157,12 @@ void loop() {
             client.setNoDelay(true);
             parser.reset();
             authenticated = false;
+            frameCount = 0;
+            acceptedCount++;
+            Serial.printf("[TCP] accepted client %s (#%lu, auth=%s)\n",
+                          client.remoteIP().toString().c_str(),
+                          (unsigned long)acceptedCount,
+                          requiresAuth() ? "required" : "open");
         }
     }
 

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -66,6 +66,7 @@ static void loadConfig() {
         cfg = {};
         cfg.hostname = "";
         cfg.tcpPort = DEFAULT_TCP_PORT;
+        cfg.wifiExternalAntenna = BOARD.wifi_antenna_switch.enabled;
         effectiveHostname = "";
         return;
     }
@@ -80,7 +81,38 @@ static void loadConfig() {
     cfg.dns2        = IPAddress(p.getUInt("dns2", 0));
     cfg.tcpToken    = p.getString("token", "");
     cfg.tcpPort     = p.getUShort("port", DEFAULT_TCP_PORT);
+    cfg.wifiExternalAntenna = p.getBool("ant_ext", BOARD.wifi_antenna_switch.enabled);
     p.end();
+}
+
+bool hasWifiAntennaSwitch() {
+    return BOARD.wifi_antenna_switch.enabled &&
+           BOARD.wifi_antenna_switch.gpio3_pin >= 0 &&
+           BOARD.wifi_antenna_switch.gpio14_pin >= 0;
+}
+
+void applyWifiAntennaSwitch() {
+    if (!hasWifiAntennaSwitch()) return;
+
+    pinMode(BOARD.wifi_antenna_switch.gpio3_pin, OUTPUT);
+    pinMode(BOARD.wifi_antenna_switch.gpio14_pin, OUTPUT);
+
+    if (cfg.wifiExternalAntenna) {
+        // Photon ESP32-C6 external Wi-Fi antenna path.
+        digitalWrite(BOARD.wifi_antenna_switch.gpio3_pin, LOW);
+        digitalWrite(BOARD.wifi_antenna_switch.gpio14_pin, HIGH);
+    } else {
+        // Internal/on-module antenna path: inverse of the external select.
+        digitalWrite(BOARD.wifi_antenna_switch.gpio3_pin, HIGH);
+        digitalWrite(BOARD.wifi_antenna_switch.gpio14_pin, LOW);
+    }
+
+    Serial.printf("[WiFi] antenna=%s gpio%d=%s gpio%d=%s\n",
+                  cfg.wifiExternalAntenna ? "external" : "internal",
+                  BOARD.wifi_antenna_switch.gpio3_pin,
+                  cfg.wifiExternalAntenna ? "LOW" : "HIGH",
+                  BOARD.wifi_antenna_switch.gpio14_pin,
+                  cfg.wifiExternalAntenna ? "HIGH" : "LOW");
 }
 
 static String buildDefaultHostname() {
@@ -142,9 +174,15 @@ void saveConfig(const Config& newCfg) {
     p.putUInt  ("dns2",  (uint32_t)newCfg.dns2);
     p.putString("token", newCfg.tcpToken);
     p.putUShort("port",  newCfg.tcpPort);
+    if (hasWifiAntennaSwitch()) {
+        p.putBool("ant_ext", newCfg.wifiExternalAntenna);
+    }
     p.end();
     cfg = newCfg;
     cfg.hostname = sanitizeHostname(cfg.hostname);
+    if (!hasWifiAntennaSwitch()) {
+        cfg.wifiExternalAntenna = false;
+    }
     refreshEffectiveHostname();
 }
 
@@ -250,12 +288,14 @@ void loadConfigOnly() {
     loadConfig();
     cfg.hostname = sanitizeHostname(cfg.hostname);
     refreshEffectiveHostname();
+    applyWifiAntennaSwitch();
 }
 
 void begin() {
     loadConfig();
     cfg.hostname = sanitizeHostname(cfg.hostname);
     refreshEffectiveHostname();
+    applyWifiAntennaSwitch();
 
     Serial.printf("[Boot] WifiManager: saved ssid='%s' host='%s' %s\n",
                   cfg.ssid.c_str(),

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -66,7 +66,7 @@ static void loadConfig() {
         cfg = {};
         cfg.hostname = "";
         cfg.tcpPort = DEFAULT_TCP_PORT;
-        cfg.wifiExternalAntenna = BOARD.wifi_antenna_switch.enabled;
+        cfg.wifiExternalAntenna = false;
         effectiveHostname = "";
         return;
     }
@@ -81,7 +81,7 @@ static void loadConfig() {
     cfg.dns2        = IPAddress(p.getUInt("dns2", 0));
     cfg.tcpToken    = p.getString("token", "");
     cfg.tcpPort     = p.getUShort("port", DEFAULT_TCP_PORT);
-    cfg.wifiExternalAntenna = p.getBool("ant_ext", BOARD.wifi_antenna_switch.enabled);
+    cfg.wifiExternalAntenna = p.getBool("ant_ext", false);
     p.end();
 }
 

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -67,6 +67,7 @@ static void loadConfig() {
         cfg.hostname = "";
         cfg.tcpPort = DEFAULT_TCP_PORT;
         cfg.wifiExternalAntenna = false;
+        cfg.gpsEnabled = false;
         effectiveHostname = "";
         return;
     }
@@ -82,6 +83,7 @@ static void loadConfig() {
     cfg.tcpToken    = p.getString("token", "");
     cfg.tcpPort     = p.getUShort("port", DEFAULT_TCP_PORT);
     cfg.wifiExternalAntenna = p.getBool("ant_ext", false);
+    cfg.gpsEnabled  = p.getBool("gps_en", false);
     p.end();
 }
 
@@ -177,6 +179,7 @@ void saveConfig(const Config& newCfg) {
     if (hasWifiAntennaSwitch()) {
         p.putBool("ant_ext", newCfg.wifiExternalAntenna);
     }
+    p.putBool("gps_en", newCfg.gpsEnabled);
     p.end();
     cfg = newCfg;
     cfg.hostname = sanitizeHostname(cfg.hostname);

--- a/firmware/tools/build_firmware_assets.py
+++ b/firmware/tools/build_firmware_assets.py
@@ -57,6 +57,11 @@ ENV_METADATA: dict[str, dict[str, str | bool]] = {
         "chip_family": "ESP32-S3",
         "web_manifest": True,
     },
+    "photon_1w_xiao_esp32c6": {
+        "name": "MeshSmith Photon-1W XIAO ESP32-C6 pyMC Modem",
+        "chip_family": "ESP32-C6",
+        "web_manifest": True,
+    },
     "rak3112_wismesh": {
         "name": "RAK3112 WisMesh pyMC Modem",
         "chip_family": "ESP32-S3",
@@ -98,6 +103,7 @@ BOARD_HEADER_TO_ENV = {
     "firmware/include/boards/heltec_tracker_v2.h": "heltec_tracker_v2",
     "firmware/include/boards/ikoka_stick.h": "ikoka_stick",
     "firmware/include/boards/xiao_wio_sx1262.h": "xiao_wio_sx1262",
+    "firmware/include/boards/photon_1w_xiao_esp32c6.h": "photon_1w_xiao_esp32c6",
     "firmware/include/boards/rak3112_wismesh.h": "rak3112_wismesh",
     "firmware/include/boards/station_g2.h": "station_g2",
     "firmware/include/boards/esp32_p4_nano.h": "esp32_p4_nano",

--- a/patches/radio-settings-additions.json
+++ b/patches/radio-settings-additions.json
@@ -3,7 +3,7 @@
   "hardware": {
     "pymc_usb": {
       "name": "pymc_usb (USB-CDC modem)",
-      "description": "ESP32-S3 board running pymc_usb firmware connected by USB cable. Tested boards: Heltec WiFi LoRa 32 V3, Ikoka Stick (XIAO ESP32-S3 + E22-P868M30S).",
+      "description": "ESP32-S3 board running pymc_usb firmware connected by USB cable. Tested boards: Heltec WiFi LoRa 32 V3, Ikoka Stick (XIAO ESP32-S3 + E22P868M30S).",
       "radio_type": "pymc_usb",
       "tx_power": 22,
       "preamble_length": 16


### PR DESCRIPTION
## PR Summary

### Overview

This PR adds first-class support for the **MeshSmith Photon-1W XIAO ESP32-C6** as a pyMC Modem firmware target.

In addition to the new board, it introduces generic support for optional GPS UARTs, battery fuel-gauge telemetry, and Wi-Fi antenna switching so these features can be enabled only on boards that declare the required hardware.

### Key Features

#### Photon-1W ESP32-C6 Firmware Target

Adds a dedicated firmware environment:

- `photon_1w_xiao_esp32c6`

Features:

- ESP32-C6 + SX1262 radio
- Wi-Fi/TCP modem transport
- HTTP and Arduino OTA updates
- External Wi-Fi antenna selection
- MAX17048 battery/fuel-gauge telemetry
- Optional GPS telemetry
- Native USB CDC support

#### GPS Support

Adds generic board-config support for optional GPS UART hardware.

Features:

- UART-based NMEA parsing
- GPS fix, position, altitude, speed, and course reporting
- GSV satellite visibility parsing
- Satellites-in-view telemetry including:
  - PRN
  - elevation
  - azimuth
  - SNR
- Persistent GPS enable/disable control
- Runtime GPS status APIs

Boards without GPS hardware do not expose GPS controls or APIs.

#### Battery & Fuel Gauge Telemetry

Adds support for MAX17048-style fuel gauges.

Exposes:

- Battery voltage
- Charge/discharge rate
- Solar charge rate telemetry

Fuel-gauge access is board-specific and remains disabled on boards that do not declare compatible hardware.

#### Wi-Fi Antenna Selection

Adds generic support for board-defined Wi-Fi antenna switches.

For Photon:

- Internal/external antenna selection
- API visibility of antenna state
- External antenna disabled by default

Boards without antenna-switch hardware remain unaffected.

#### Improved Recovery Behavior

Radio initialization failures no longer prevent access to:

- Wi-Fi
- Configuration portal
- OTA updates

This allows recovery from radio configuration issues without requiring physical access to the device.

#### Expanded Diagnostics

Adds additional modem diagnostics and API telemetry:

- `/api/system`
- `/api/stats`
- `/api/gps`
- `/api/config`

Including:

- Battery telemetry
- Charge-rate telemetry
- Network state
- GPS status
- Radio state
- TCP modem diagnostics

### Files Changed

- `INSTALL.md`
- `README.md`
- `firmware/platformio.ini`
- `firmware/include/board_config.h`
- `firmware/include/boards/photon_1w_xiao_esp32c6.h`
- `firmware/include/gps_manager.h`
- `firmware/include/runtime_stats.h`
- `firmware/include/wifi_manager.h`
- `firmware/src/config_portal.cpp`
- `firmware/src/gps_manager.cpp`
- `firmware/src/main.cpp`
- `firmware/src/ota_manager.cpp`
- `firmware/src/tcp_server.cpp`
- `firmware/src/wifi_manager.cpp`
- `firmware/tools/build_firmware_assets.py`
- `patches/radio-settings-additions.json`

### Validation

Build validation:

```bash
pio run -e photon_1w_xiao_esp32c6
```

Result:

```text
SUCCESS
RAM:   15.3% (50,168 / 327,680 bytes)
Flash: 59.5% (1,170,497 / 1,966,080 bytes)
```

### Hardware Verification

Verified on a live Photon-1W device.

Confirmed:

- Wi-Fi connectivity
- TCP modem operation
- Battery telemetry
- Charge-rate reporting
- GPS parsing
- Satellite visibility reporting
- GPS enable/disable persistence
- API telemetry endpoints

GPS verification included:

- Valid GPS fix
- Satellite usage counts
- Satellites-in-view telemetry
- PRN, elevation, azimuth, and SNR reporting

### Backwards Compatibility

- GPS controls only appear on boards that declare GPS hardware.
- Wi-Fi antenna controls only appear on boards that declare antenna-switch hardware.
- Boards without fuel-gauge support continue using existing battery reporting paths.
- Existing board definitions remain unchanged.
- Existing non-GPS boards continue to operate without GPS-related UI or API controls.

### Assessment

This is primarily an additive board-support PR with supporting infrastructure for optional GPS, battery telemetry, and Wi-Fi antenna management. Validation includes successful firmware builds and live hardware testing of the Photon-1W platform, along with verification that non-GPS boards continue to behave correctly.