### PR TITLE
fix: align T114 board config with GPS fields

### DIFF
--- a/firmware/include/boards/heltec_t114.h
+++ b/firmware/include/boards/heltec_t114.h
@@ -108,6 +108,10 @@ inline const BoardConfig BOARD = {
     10,      // pin_protocol_uart_tx
     921600,  // protocol_uart_baud
 
+    -1,    // pin_gps_uart_rx — no GPS UART claimed by this firmware profile
+    -1,    // pin_gps_uart_tx
+    9600,  // gps_uart_baud
+
     {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 


### PR DESCRIPTION
## Summary
- Adds explicit disabled GPS UART fields to the positional Heltec T114 board initializer.
- Fixes the main firmware asset workflow failure after the BoardConfig GPS fields were added.
- Keeps the T114 profile from claiming GPS hardware.

## Test plan
- `cd firmware && pio run -e heltec_t114`
- `python3 firmware/tools/build_firmware_assets.py --variant heltec_t114`
