### PR TITLE
feat: add generic Wi-Fi setup reset controls

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1286,7 +1286,7 @@ void noteTransportFrameError(uint8_t err_code) {
 
 // ─── Setup ───────────────────────────────────────────────────
 void setup() {
-    // PRG held ≥3s at boot → wipe Wi-Fi NVS and reboot. Must come before
+    // PRG held ≥5s at boot → wipe Wi-Fi NVS and reboot. Must come before
     // other init so button sampling is clean.
     WifiManager::checkResetButton();
 
@@ -1646,13 +1646,14 @@ void loop() {
     }
 
     // PRG short-tap: cycle SLEEP → STATUS → RADIO → DIAGNOSTICS → STATUS → …
-    // (Factory reset on 3 s hold-at-boot is handled in setup()/checkResetButton.)
+    // (Wi-Fi setup reset on 5 s hold-at-boot is handled in setup()/checkResetButton.)
     // Boards with pin_user_button < 0 (e.g. ESP32-P4-Nano where the BOOT
     // button shares a pin with RMII Ethernet TXD1) skip polling entirely.
     bool btn = false;
     if (BOARD.pin_user_button >= 0) {
         btn = (digitalRead(BOARD.pin_user_button) == (BOARD.user_button_active_low ? LOW : HIGH));
     }
+
     if (btn && millis() > prgIgnoreUntil) {
         prgIgnoreUntil = millis() + PRG_DEBOUNCE_MS;
         oledWakeUntil  = millis() + OLED_WAKE_DURATION_MS;

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -664,7 +664,7 @@ static void handleRoot() {
               "label{display:block;margin-top:.8em;font-weight:600}input{width:100%;padding:.55em;box-sizing:border-box;font-size:1em;border:1px solid #ccc;border-radius:6px}"
               "input[type=file]{padding:.3em 0;border:0}input[type=checkbox]{width:auto;margin-right:.45em}"
               ".checkline{display:flex;align-items:center;gap:.35em;margin-top:.8em}button{margin-top:.9em;padding:.6em 1em;background:#2f6f5e;color:#fff;border:0;border-radius:6px;cursor:pointer}"
-              "code{font-family:ui-monospace,SFMono-Regular,monospace;background:#f3f3f3;padding:.1em .35em;border-radius:4px}"
+              "button.danger{background:#b3261e}code{font-family:ui-monospace,SFMono-Regular,monospace;background:#f3f3f3;padding:.1em .35em;border-radius:4px}"
               "@media (max-width:640px){body{padding:0 .75em}}</style></head><body>");
     body += "<h2>" + title + "</h2>";
     body += "<div class='summary'><p><strong>mDNS</strong> " + hostname + ".local</p>";
@@ -748,6 +748,12 @@ static void handleRoot() {
               "<input type='password' name='confirm' autocomplete='new-password' required minlength='1' maxlength='64'>"
               "<button type='submit'>Save password</button>"
               "</form><p class='m'>Password changes take effect on the next request.</p></div></details>");
+
+    body += F("<details><summary>Wi-Fi Setup Mode</summary><div class='inside'>"
+              "<p>Clear the saved modem configuration and reboot into the open <code>LoRa-Modem-XXXX</code> setup AP.</p>"
+              "<form method='POST' action='/wifi-reset' onsubmit=\"return confirm('Clear saved modem configuration and reboot into Wi-Fi setup AP?');\">"
+              "<button class='danger' type='submit'>Enter Wi-Fi Setup Mode</button>"
+              "</form><p class='m'>Use this before moving the modem to a different Wi-Fi network.</p></div></details>");
 
     body += F("<details><summary>Reboot</summary><div class='inside'>"
               "<p>Restart the modem without changing any settings.</p>"
@@ -967,6 +973,18 @@ static void handleApiReboot() {
     sendJson(200, F("{\"status\":\"rebooting\"}"));
     delay(500);
     ESP.restart();
+}
+
+static void handleWifiReset() {
+    if (!checkAuth()) return;
+
+    Serial.printf("[OTA] Wi-Fi setup reset requested by %s\n",
+                  httpServer->client().remoteIP().toString().c_str());
+    sendSimplePage(F("Entering Wi-Fi setup mode"),
+                   F("Entering Wi-Fi setup mode"),
+                   F("Saved modem configuration is being cleared. The modem will reboot into the open LoRa-Modem setup AP."));
+    delay(500);
+    WifiManager::factoryReset();   // does not return
 }
 
 static void handleHostnameSave() {
@@ -1230,6 +1248,7 @@ void begin(const String& hn, const String& tk) {
     httpServer->on("/gps",     HTTP_POST, handleGpsSave);
     httpServer->on("/token",  HTTP_POST, handleTokenSave);
     httpServer->on("/auth",   HTTP_POST, handleAuthSave);
+    httpServer->on("/wifi-reset", HTTP_POST, handleWifiReset);
     httpServer->on("/reboot", HTTP_POST, handleReboot);
     httpServer->on("/update", HTTP_POST, handleUpdateResult, handleUpdateUpload);
     httpServer->onNotFound([]() { httpServer->send(404, "text/plain", "Not found"); });

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -14,7 +14,7 @@ namespace WifiManager {
 static constexpr const char* NVS_NAMESPACE         = "lora_modem";
 static constexpr uint16_t    DEFAULT_TCP_PORT      = 5055;
 static constexpr uint32_t    STA_CONNECT_TIMEOUT_MS = 30000;
-static constexpr uint32_t    PRG_RESET_HOLD_MS     = 3000;
+static constexpr uint32_t    PRG_RESET_HOLD_MS     = 5000;
 static constexpr uint8_t     MAX_HOSTNAME_LEN      = 32;
 
 static Config  cfg;


### PR DESCRIPTION
## PR Summary

### Title

`feat: add generic Wi-Fi setup reset controls`

### Overview

This PR adds a generic, authenticated way to return a modem to Wi-Fi setup mode from the web UI.

It introduces a new **Wi-Fi Setup Mode** section in the modem OTA/config interface with an **Enter Wi-Fi Setup Mode** button. When confirmed, the modem clears saved Wi-Fi/modem configuration and reboots into the open `LoRa-Modem-XXXX` setup AP.

The feature uses generic modem wording so it applies to all Wi-Fi/web-UI capable boards.

### Changes

#### Web UI Reset Control

- Adds a new **Wi-Fi Setup Mode** section to the modem web UI.
- Adds a red/danger-styled **Enter Wi-Fi Setup Mode** button.
- Adds a browser confirmation prompt before reset.
- Adds authenticated `POST /wifi-reset` handling.
- Calls `WifiManager::factoryReset()` after returning the response page.

#### Hardware Reset Behavior

- Changes boot-time PRG/BOOT reset hold from 3 seconds to 5 seconds.
- Keeps the hardware reset action limited to boot-time only.
- Removes runtime long-hold reset behavior.
- Preserves existing runtime short-press behavior for display screen cycling.

### Behavior

#### From the Web UI

1. Open the modem web UI.
2. Expand **Wi-Fi Setup Mode**.
3. Click **Enter Wi-Fi Setup Mode**.
4. Confirm the browser prompt.
5. The modem clears saved config and reboots into the open `LoRa-Modem-XXXX` setup AP.

#### From the Hardware Button

- Hold PRG/BOOT during boot for at least 5 seconds to clear saved config and reboot into setup AP.
- During normal runtime, short press still cycles display screens.
- Runtime long-hold reset is intentionally not implemented.

### Files Changed

- `firmware/src/ota_manager.cpp`
- `firmware/src/wifi_manager.cpp`
- `firmware/src/main.cpp`

### Validation

```bash
git diff --check
```

Result: passed.