### PR TITLE
Fix Heltec V4 revision-specific RF and GPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Per-board highlights (full pin numbers in the headers, mDNS prefix is
 
 - **Heltec V3** — onboard SSD1306, bare SX1262, max 22 dBm.
 - **Heltec V4** — onboard SSD1306, SX1262 + V4.x PA/LNA front-end, native USB-CDC, max 22 dBm SX1262 command power.
+- **Heltec V4.2** — dedicated GC1109 PA/FEM build with VFEM/CSD enabled and GC1109 CPS driven high for full PA mode.
+- **Heltec V4.3** — dedicated KCT8103L PA/FEM build with SX1262 boosted RX gain enabled and FEM RX LNA bypassed for lower noise floor.
 - **Heltec Wireless Tracker V2** — ESP32-S3 + SX1262 + KCT8103L PA/FEM, ST7735 TFT 160×80, native USB-CDC, max 22 dBm SX1262 command power.
 - **Ikoka Stick** — XIAO ESP32-S3 + E22P868M30S, EN-held + DIO2-as-RF-switch, max 30 dBm chip / +10 dB PA, external OLED.
 - **XIAO Wio-SX1262** — Seeed XIAO ESP32-S3 + bare SX1262, no OLED.

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -235,6 +235,10 @@ extern const BoardConfig BOARD;
 #  include "boards/heltec_v3.h"
 #elif defined(BOARD_HELTEC_V4)
 #  include "boards/heltec_v4.h"
+#elif defined(BOARD_HELTEC_V42)
+#  include "boards/heltec_v42.h"
+#elif defined(BOARD_HELTEC_V43)
+#  include "boards/heltec_v43.h"
 #elif defined(BOARD_IKOKA_STICK)
 #  include "boards/ikoka_stick.h"
 #elif defined(BOARD_LILYGO_T3S3)
@@ -256,5 +260,5 @@ extern const BoardConfig BOARD;
 #elif defined(BOARD_STATION_G2)
 #  include "boards/station_g2.h"
 #else
-#  error "No board selected — add one of -DBOARD_HELTEC_V3 / -DBOARD_HELTEC_V4 / -DBOARD_IKOKA_STICK / -DBOARD_LILYGO_T3S3 / -DBOARD_RAK3112_WISMESH / -DBOARD_ESP32_P4_NANO / -DBOARD_HELTEC_T114 / -DBOARD_HELTEC_TRACKER_V2 / -DBOARD_XIAO_WIO_SX1262 / -DBOARD_PHOTON_1W_XIAO_ESP32C6 / -DBOARD_XIAO_NRF52_WIO / -DBOARD_STATION_G2 to platformio.ini build_flags"
+#  error "No board selected — add one of -DBOARD_HELTEC_V3 / -DBOARD_HELTEC_V4 / -DBOARD_HELTEC_V42 / -DBOARD_HELTEC_V43 / -DBOARD_IKOKA_STICK / -DBOARD_LILYGO_T3S3 / -DBOARD_RAK3112_WISMESH / -DBOARD_ESP32_P4_NANO / -DBOARD_HELTEC_T114 / -DBOARD_HELTEC_TRACKER_V2 / -DBOARD_XIAO_WIO_SX1262 / -DBOARD_PHOTON_1W_XIAO_ESP32C6 / -DBOARD_XIAO_NRF52_WIO / -DBOARD_STATION_G2 to platformio.ini build_flags"
 #endif

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -188,6 +188,10 @@ struct BoardConfig {
     int8_t   pin_gps_uart_rx = -1;
     int8_t   pin_gps_uart_tx = -1;
     uint32_t gps_uart_baud = 9600;
+    int8_t   pin_gps_enable = -1;       // optional GPS/GNSS power-enable GPIO
+    bool     gps_enable_active_high = true;
+    int8_t   pin_gps_reset = -1;        // optional GPS reset GPIO
+    bool     gps_reset_active_high = false;
 
     // ─── On-board Ethernet (RMII PHY) ───────────────────────
     // Set ethernet.enabled = true on boards with an internal EMAC +

--- a/firmware/include/board_config.h
+++ b/firmware/include/board_config.h
@@ -192,6 +192,7 @@ struct BoardConfig {
     bool     gps_enable_active_high = true;
     int8_t   pin_gps_reset = -1;        // optional GPS reset GPIO
     bool     gps_reset_active_high = false;
+    bool     gps_send_casic_config = true; // false for modules/boards that should be left at defaults
 
     // ─── On-board Ethernet (RMII PHY) ───────────────────────
     // Set ethernet.enabled = true on boards with an internal EMAC +

--- a/firmware/include/boards/heltec_t114.h
+++ b/firmware/include/boards/heltec_t114.h
@@ -111,6 +111,10 @@ inline const BoardConfig BOARD = {
     -1,    // pin_gps_uart_rx — no GPS UART claimed by this firmware profile
     -1,    // pin_gps_uart_tx
     9600,  // gps_uart_baud
+    -1,    // pin_gps_enable
+    true,  // gps_enable_active_high
+    -1,    // pin_gps_reset
+    false, // gps_reset_active_high
 
     {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},

--- a/firmware/include/boards/heltec_t114.h
+++ b/firmware/include/boards/heltec_t114.h
@@ -115,6 +115,7 @@ inline const BoardConfig BOARD = {
     true,  // gps_enable_active_high
     -1,    // pin_gps_reset
     false, // gps_reset_active_high
+    true,  // gps_send_casic_config
 
     {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},

--- a/firmware/include/boards/heltec_v4.h
+++ b/firmware/include/boards/heltec_v4.h
@@ -65,6 +65,20 @@ inline const BoardConfig BOARD = {
     .pin_protocol_uart_rx = -1,
     .pin_protocol_uart_tx = -1,
     .protocol_uart_baud   = 921600,
+
+    // Heltec V4 GNSS connector, matching the V4.2 schematic and MeshCore:
+    //   GPIO38 RX_GPS: GPS TX -> ESP32-S3 RX
+    //   GPIO39 TX_GPS: ESP32-S3 TX -> GPS RX
+    //   GPIO34 VGNSS_Ctrl: active-low GNSS power enable
+    //   GPIO42 RST_GPS: active-low GNSS reset
+    .pin_gps_uart_rx = 38,
+    .pin_gps_uart_tx = 39,
+    .gps_uart_baud   = 9600,
+    .pin_gps_enable = 34,
+    .gps_enable_active_high = false,
+    .pin_gps_reset = 42,
+    .gps_reset_active_high = false,
+
     .ethernet = { .enabled = false },
 
     // Heltec V4.x front-end support:

--- a/firmware/include/boards/heltec_v4.h
+++ b/firmware/include/boards/heltec_v4.h
@@ -66,18 +66,20 @@ inline const BoardConfig BOARD = {
     .pin_protocol_uart_tx = -1,
     .protocol_uart_baud   = 921600,
 
-    // Heltec V4 GNSS connector, matching the V4.2 schematic and MeshCore:
-    //   GPIO38 RX_GPS: GPS TX -> ESP32-S3 RX
-    //   GPIO39 TX_GPS: ESP32-S3 TX -> GPS RX
+    // Heltec V4 GNSS connector, matching MeshCore's working runtime mapping.
+    // MeshCore defines PIN_GPS_RX=38 and PIN_GPS_TX=39, then calls
+    // Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX), so Arduino's RX argument is
+    // GPIO39 and TX argument is GPIO38.
     //   GPIO34 VGNSS_Ctrl: active-low GNSS power enable
     //   GPIO42 RST_GPS: active-low GNSS reset
-    .pin_gps_uart_rx = 38,
-    .pin_gps_uart_tx = 39,
+    .pin_gps_uart_rx = 39,
+    .pin_gps_uart_tx = 38,
     .gps_uart_baud   = 9600,
     .pin_gps_enable = 34,
     .gps_enable_active_high = false,
     .pin_gps_reset = 42,
     .gps_reset_active_high = false,
+    .gps_send_casic_config = false,
 
     .ethernet = { .enabled = false },
 

--- a/firmware/include/boards/heltec_v42.h
+++ b/firmware/include/boards/heltec_v42.h
@@ -68,18 +68,20 @@ inline const BoardConfig BOARD = {
     .pin_protocol_uart_tx = -1,
     .protocol_uart_baud   = 921600,
 
-    // Heltec V4.2 GNSS connector, matching the V4.2 schematic and MeshCore:
-    //   GPIO38 RX_GPS: GPS TX -> ESP32-S3 RX
-    //   GPIO39 TX_GPS: ESP32-S3 TX -> GPS RX
+    // Heltec V4.2 GNSS connector, matching MeshCore's working runtime mapping.
+    // MeshCore defines PIN_GPS_RX=38 and PIN_GPS_TX=39, then calls
+    // Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX), so Arduino's RX argument is
+    // GPIO39 and TX argument is GPIO38.
     //   GPIO34 VGNSS_Ctrl: active-low GNSS power enable
     //   GPIO42 RST_GPS: active-low GNSS reset
-    .pin_gps_uart_rx = 38,
-    .pin_gps_uart_tx = 39,
+    .pin_gps_uart_rx = 39,
+    .pin_gps_uart_tx = 38,
     .gps_uart_baud   = 9600,
     .pin_gps_enable = 34,
     .gps_enable_active_high = false,
     .pin_gps_reset = 42,
     .gps_reset_active_high = false,
+    .gps_send_casic_config = false,
 
     .ethernet = { .enabled = false },
 

--- a/firmware/include/boards/heltec_v42.h
+++ b/firmware/include/boards/heltec_v42.h
@@ -67,6 +67,20 @@ inline const BoardConfig BOARD = {
     .pin_protocol_uart_rx = -1,
     .pin_protocol_uart_tx = -1,
     .protocol_uart_baud   = 921600,
+
+    // Heltec V4.2 GNSS connector, matching the V4.2 schematic and MeshCore:
+    //   GPIO38 RX_GPS: GPS TX -> ESP32-S3 RX
+    //   GPIO39 TX_GPS: ESP32-S3 TX -> GPS RX
+    //   GPIO34 VGNSS_Ctrl: active-low GNSS power enable
+    //   GPIO42 RST_GPS: active-low GNSS reset
+    .pin_gps_uart_rx = 38,
+    .pin_gps_uart_tx = 39,
+    .gps_uart_baud   = 9600,
+    .pin_gps_enable = 34,
+    .gps_enable_active_high = false,
+    .pin_gps_reset = 42,
+    .gps_reset_active_high = false,
+
     .ethernet = { .enabled = false },
 
     // Heltec V4.2 GC1109 front-end support:

--- a/firmware/include/boards/heltec_v42.h
+++ b/firmware/include/boards/heltec_v42.h
@@ -1,0 +1,84 @@
+// =============================================================
+// boards/heltec_v42.h — Heltec WiFi LoRa 32 V4.2
+// ESP32-S3 + SX1262 + GC1109 PA/FEM.
+//
+// The core board, display, battery, and LoRa pin map match heltec_v4.h.
+// V4.2 uses the GC1109 front-end policy from Meshtastic's V4 mapping:
+// keep the front-end enabled and drive CPS high for full PA mode. This is
+// intentionally separate from heltec_v43.h, which uses KCT8103L CTX for
+// receive-LNA bypass.
+// =============================================================
+#pragma once
+
+inline const BoardConfig BOARD = {
+    .name        = "Heltec V4.2",
+    .fw_suffix   = "heltec-v42",
+    .mdns_prefix = "heltec-v42",
+
+    // SX1262 control + SPI pins. Unlike V3, the V4 variant is repo-local, so
+    // bind SPI explicitly to the Heltec V4 pins from pins_arduino.h.
+    .pin_lora_nss  = 8,
+    .pin_lora_rst  = 12,
+    .pin_lora_busy = 13,
+    .pin_lora_dio1 = 14,
+    .pin_lora_sck  = 9,
+    .pin_lora_miso = 11,
+    .pin_lora_mosi = 10,
+
+    .rf_switch = {
+        .en_pin            = -1,
+        .en_low_hold_ms    = 0,
+        .rx_pin            = -1,
+        .tx_pin            = -1,
+        .dio2_as_rf_switch = true,  // DIO2 drives the SX1262/FEM TX/RX path
+    },
+
+    // Built-in 0.96" SSD1306 OLED on the VEXT rail.
+    .pin_i2c_sda      = 17,
+    .pin_i2c_scl      = 18,
+    .pin_i2c_oled_rst = 21,
+    .pin_vext_enable_low = 36,
+
+    .pin_user_button         = 0,
+    .user_button_active_low  = true,
+
+    // LiPo monitor from Heltec/Meshtastic mapping: GPIO1 through a high-
+    // impedance divider, gated by GPIO37 HIGH. Multiplier includes the
+    // divider ratio plus the calibration factor used by the upstream map.
+    .battery = {
+        .pin = 1,
+        .enable_pin = 37,
+        .enable_active_high = true,
+        .multiplier = 4.90f * 1.045f,
+    },
+
+    // Keep the firmware's host-visible setting equivalent to Heltec V3/bare
+    // SX1262. V4.2's front-end can amplify RF output, but RadioLib still
+    // configures SX1262 output power, so clamp the chip command to 22 dBm.
+    .max_tx_power_dbm = 22,
+
+    .use_dio3_tcxo = true,
+    .tcxo_voltage  = 1.8f,
+
+    .has_lora_radio = true,
+    .has_wifi       = true,
+    .has_network    = true,
+
+    .pin_protocol_uart_rx = -1,
+    .pin_protocol_uart_tx = -1,
+    .protocol_uart_baud   = 921600,
+    .ethernet = { .enabled = false },
+
+    // Heltec V4.2 GC1109 front-end support:
+    //   GPIO7  VFEM_Ctrl / LDO enable: HIGH = front-end rail on
+    //   GPIO2  FEM CSD/chip enable:    HIGH = PA/LNA enabled
+    //   GPIO46 GC1109 CPS:             HIGH = full PA mode
+    // GPIO5 is KCT8103L-only on V4.3 and is intentionally not driven here.
+    // SX1262 DIO2 remains the automatic TX/RX path-select line.
+    .static_gpios = {
+        { 7,  true },
+        { 2,  true },
+        { 46, true },
+    },
+    .static_gpio_count = 3,
+};

--- a/firmware/include/boards/heltec_v43.h
+++ b/firmware/include/boards/heltec_v43.h
@@ -1,0 +1,87 @@
+// =============================================================
+// boards/heltec_v43.h — Heltec WiFi LoRa 32 V4.3
+// ESP32-S3 + SX1262 + KCT8103L PA/FEM, with FEM LNA bypassed.
+//
+// The core board, display, battery, and LoRa pin map match heltec_v4.h.
+// V4.3 swaps the front-end to KCT8103L; recent MeshCore firmware bypasses
+// its receive LNA because the PA/FEM can raise the receive noise floor.
+// This dedicated pyMC modem variant keeps SX1262 boosted RX gain enabled
+// while holding KCT8103L CTX high for FEM LNA bypass.
+// =============================================================
+#pragma once
+
+inline const BoardConfig BOARD = {
+    .name        = "Heltec V4.3",
+    .fw_suffix   = "heltec-v43",
+    .mdns_prefix = "heltec-v43",
+
+    // SX1262 control + SPI pins. Unlike V3, the V4 variant is repo-local, so
+    // bind SPI explicitly to the Heltec V4 pins from pins_arduino.h.
+    .pin_lora_nss  = 8,
+    .pin_lora_rst  = 12,
+    .pin_lora_busy = 13,
+    .pin_lora_dio1 = 14,
+    .pin_lora_sck  = 9,
+    .pin_lora_miso = 11,
+    .pin_lora_mosi = 10,
+
+    .rf_switch = {
+        .en_pin            = -1,
+        .en_low_hold_ms    = 0,
+        .rx_pin            = -1,
+        .tx_pin            = -1,
+        .dio2_as_rf_switch = true,  // DIO2 drives the SX1262/FEM TX/RX path
+    },
+
+    // Built-in 0.96" SSD1306 OLED on the VEXT rail.
+    .pin_i2c_sda      = 17,
+    .pin_i2c_scl      = 18,
+    .pin_i2c_oled_rst = 21,
+    .pin_vext_enable_low = 36,
+
+    .pin_user_button         = 0,
+    .user_button_active_low  = true,
+
+    // LiPo monitor from Heltec/Meshtastic mapping: GPIO1 through a high-
+    // impedance divider, gated by GPIO37 HIGH. Multiplier includes the
+    // divider ratio plus the calibration factor used by the upstream map.
+    .battery = {
+        .pin = 1,
+        .enable_pin = 37,
+        .enable_active_high = true,
+        .multiplier = 4.90f * 1.045f,
+    },
+
+    // Keep the firmware's host-visible setting equivalent to Heltec V3/bare
+    // SX1262. V4.3's front-end can amplify RF output, but RadioLib still
+    // configures SX1262 output power, so clamp the chip command to 22 dBm.
+    .max_tx_power_dbm = 22,
+
+    .use_dio3_tcxo = true,
+    .tcxo_voltage  = 1.8f,
+
+    // Goal: radio.rxgain on + radio.fem.rxgain off.
+    .sx126x_rx_boosted_gain = true,
+
+    .has_lora_radio = true,
+    .has_wifi       = true,
+    .has_network    = true,
+
+    .pin_protocol_uart_rx = -1,
+    .pin_protocol_uart_tx = -1,
+    .protocol_uart_baud   = 921600,
+    .ethernet = { .enabled = false },
+
+    // Heltec V4.3 KCT8103L front-end support:
+    //   GPIO7 VFEM_Ctrl / LDO enable: HIGH = front-end rail on
+    //   GPIO2 KCT8103L CSD/chip enable: HIGH = PA/FEM enabled
+    //   GPIO5 KCT8103L CTX: HIGH = RX LNA bypass, LOW = RX LNA on
+    // GPIO46 is GC1109-only on V4.2 and is intentionally not driven here.
+    // SX1262 DIO2 remains the automatic TX/RX path-select line.
+    .static_gpios = {
+        { 7, true },
+        { 2, true },
+        { 5, true },
+    },
+    .static_gpio_count = 3,
+};

--- a/firmware/include/boards/heltec_v43.h
+++ b/firmware/include/boards/heltec_v43.h
@@ -71,18 +71,20 @@ inline const BoardConfig BOARD = {
     .pin_protocol_uart_tx = -1,
     .protocol_uart_baud   = 921600,
 
-    // Heltec V4.3 GNSS connector keeps the base V4 GPS pinout:
-    //   GPIO38 RX_GPS: GPS TX -> ESP32-S3 RX
-    //   GPIO39 TX_GPS: ESP32-S3 TX -> GPS RX
+    // Heltec V4.3 GNSS connector, matching MeshCore's working runtime mapping.
+    // MeshCore defines PIN_GPS_RX=38 and PIN_GPS_TX=39, then calls
+    // Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX), so Arduino's RX argument is
+    // GPIO39 and TX argument is GPIO38.
     //   GPIO34 VGNSS_Ctrl: active-low GNSS power enable
     //   GPIO42 RST_GPS: active-low GNSS reset
-    .pin_gps_uart_rx = 38,
-    .pin_gps_uart_tx = 39,
+    .pin_gps_uart_rx = 39,
+    .pin_gps_uart_tx = 38,
     .gps_uart_baud   = 9600,
     .pin_gps_enable = 34,
     .gps_enable_active_high = false,
     .pin_gps_reset = 42,
     .gps_reset_active_high = false,
+    .gps_send_casic_config = false,
 
     .ethernet = { .enabled = false },
 

--- a/firmware/include/boards/heltec_v43.h
+++ b/firmware/include/boards/heltec_v43.h
@@ -70,6 +70,20 @@ inline const BoardConfig BOARD = {
     .pin_protocol_uart_rx = -1,
     .pin_protocol_uart_tx = -1,
     .protocol_uart_baud   = 921600,
+
+    // Heltec V4.3 GNSS connector keeps the base V4 GPS pinout:
+    //   GPIO38 RX_GPS: GPS TX -> ESP32-S3 RX
+    //   GPIO39 TX_GPS: ESP32-S3 TX -> GPS RX
+    //   GPIO34 VGNSS_Ctrl: active-low GNSS power enable
+    //   GPIO42 RST_GPS: active-low GNSS reset
+    .pin_gps_uart_rx = 38,
+    .pin_gps_uart_tx = 39,
+    .gps_uart_baud   = 9600,
+    .pin_gps_enable = 34,
+    .gps_enable_active_high = false,
+    .pin_gps_reset = 42,
+    .gps_reset_active_high = false,
+
     .ethernet = { .enabled = false },
 
     // Heltec V4.3 KCT8103L front-end support:

--- a/firmware/include/boards/xiao_nrf52_wio.h
+++ b/firmware/include/boards/xiao_nrf52_wio.h
@@ -110,6 +110,7 @@ inline const BoardConfig BOARD = {
     true,   // gps_enable_active_high
     -1,     // pin_gps_reset
     false,  // gps_reset_active_high
+    true,   // gps_send_casic_config
 
     {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},

--- a/firmware/include/boards/xiao_nrf52_wio.h
+++ b/firmware/include/boards/xiao_nrf52_wio.h
@@ -103,6 +103,14 @@ inline const BoardConfig BOARD = {
     -1,      // pin_protocol_uart_tx
     921600,  // protocol_uart_baud
 
+    -1,     // pin_gps_uart_rx
+    -1,     // pin_gps_uart_tx
+    9600,   // gps_uart_baud
+    -1,     // pin_gps_enable
+    true,   // gps_enable_active_high
+    -1,     // pin_gps_reset
+    false,  // gps_reset_active_high
+
     {false, BoardConfig::EthernetPhy::NONE, -1, -1, -1, -1, false, false,
      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -3,6 +3,8 @@
 ; Supported boards share the same source tree; pick one env per build:
 ;   pio run -e heltec_v3      → Heltec WiFi LoRa 32 V3 (bare SX1262)
 ;   pio run -e heltec_v4      → Heltec WiFi LoRa 32 V4 (SX1262 + FEM)
+;   pio run -e heltec_v42     → Heltec WiFi LoRa 32 V4.2 (GC1109 FEM)
+;   pio run -e heltec_v43     → Heltec WiFi LoRa 32 V4.3 (KCT8103L LNA bypass)
 ;   pio run -e ikoka_stick    → XIAO ESP32-S3 + Ebyte E22P868M30S
 ; =============================================================
 
@@ -61,6 +63,29 @@ build_flags =
     ${env.build_flags}
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DBOARD_HELTEC_V4
+
+[env:heltec_v42]
+; Heltec WiFi LoRa 32 V4.2: same ESP32-S3/SX1262 pin map as heltec_v4, but
+; dedicated GC1109 PA/FEM policy with CPS driven high for full PA mode.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
+board = heltec_wifi_lora_32_V4
+board_build.variants_dir = variants
+build_flags =
+    ${env.build_flags}
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HELTEC_V42
+
+[env:heltec_v43]
+; Heltec WiFi LoRa 32 V4.3: same ESP32-S3/SX1262 pin map as heltec_v4, but
+; dedicated KCT8103L PA/FEM policy with FEM RX LNA bypassed to improve noise
+; floor while keeping the SX1262's boosted RX gain enabled.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
+board = heltec_wifi_lora_32_V4
+board_build.variants_dir = variants
+build_flags =
+    ${env.build_flags}
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_HELTEC_V43
 
 [env:heltec_tracker_v2]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip

--- a/firmware/src/gps_manager.cpp
+++ b/firmware/src/gps_manager.cpp
@@ -18,6 +18,41 @@ static size_t nextConfigCommand = CONFIG_COMMAND_COUNT;
 
 #ifdef ARDUINO_ARCH_ESP32
 static HardwareSerial& gpsSerial = Serial1;
+
+static int gpsActiveLevel(bool activeHigh) {
+    return activeHigh ? HIGH : LOW;
+}
+
+static int gpsInactiveLevel(bool activeHigh) {
+    return activeHigh ? LOW : HIGH;
+}
+
+static void setGpsPower(bool on) {
+    if (BOARD.pin_gps_enable < 0) return;
+    pinMode(BOARD.pin_gps_enable, OUTPUT);
+    digitalWrite(BOARD.pin_gps_enable,
+                 on ? gpsActiveLevel(BOARD.gps_enable_active_high)
+                    : gpsInactiveLevel(BOARD.gps_enable_active_high));
+}
+
+static void setGpsReset(bool active) {
+    if (BOARD.pin_gps_reset < 0) return;
+    pinMode(BOARD.pin_gps_reset, OUTPUT);
+    digitalWrite(BOARD.pin_gps_reset,
+                 active ? gpsActiveLevel(BOARD.gps_reset_active_high)
+                        : gpsInactiveLevel(BOARD.gps_reset_active_high));
+}
+
+static void releaseGpsReset() {
+    setGpsReset(false);
+}
+
+static void pulseGpsReset() {
+    if (BOARD.pin_gps_reset < 0) return;
+    setGpsReset(true);
+    delay(120);
+    releaseGpsReset();
+}
 #endif
 
 static String jsonEscape(const String& value) {
@@ -308,17 +343,24 @@ void setEnabled(bool enabled) {
 
     if (enabled) {
         resetRuntimeFields();
+        setGpsPower(true);
+        releaseGpsReset();
+        pulseGpsReset();
+        delay(50);
         gpsSerial.begin(BOARD.gps_uart_baud, SERIAL_8N1, BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx);
         current.enabled = true;
-        Serial.printf("[GPS] UART GPS enabled on RX=%d TX=%d baud=%lu\n",
+        Serial.printf("[GPS] UART GPS enabled on RX=%d TX=%d baud=%lu EN=%d RST=%d\n",
                       BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx,
-                      (unsigned long)BOARD.gps_uart_baud);
+                      (unsigned long)BOARD.gps_uart_baud,
+                      BOARD.pin_gps_enable, BOARD.pin_gps_reset);
         scheduleAtgm336hConfig();
     } else {
         gpsSerial.end();
         current.enabled = false;
         nextConfigCommand = CONFIG_COMMAND_COUNT;
         resetRuntimeFields();
+        setGpsReset(true);
+        setGpsPower(false);
         Serial.println("[GPS] UART GPS disabled");
     }
 #else
@@ -424,6 +466,10 @@ String buildJson() {
     body += String(BOARD.pin_gps_uart_tx);
     body += F(",\"uart_baud\":");
     body += String(BOARD.gps_uart_baud);
+    body += F(",\"enable_pin\":");
+    body += String(BOARD.pin_gps_enable);
+    body += F(",\"reset_pin\":");
+    body += String(BOARD.pin_gps_reset);
     body += F(",\"age_ms\":");
     body += snap.lastUpdateMs ? String((uint32_t)(millis() - snap.lastUpdateMs)) : String("null");
     body += F("}}");

--- a/firmware/src/gps_manager.cpp
+++ b/firmware/src/gps_manager.cpp
@@ -50,7 +50,7 @@ static void releaseGpsReset() {
 static void pulseGpsReset() {
     if (BOARD.pin_gps_reset < 0) return;
     setGpsReset(true);
-    delay(120);
+    delay(10);
     releaseGpsReset();
 }
 #endif
@@ -353,7 +353,11 @@ void setEnabled(bool enabled) {
                       BOARD.pin_gps_uart_rx, BOARD.pin_gps_uart_tx,
                       (unsigned long)BOARD.gps_uart_baud,
                       BOARD.pin_gps_enable, BOARD.pin_gps_reset);
-        scheduleAtgm336hConfig();
+        if (BOARD.gps_send_casic_config) {
+            scheduleAtgm336hConfig();
+        } else {
+            nextConfigCommand = CONFIG_COMMAND_COUNT;
+        }
     } else {
         gpsSerial.end();
         current.enabled = false;

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -206,9 +206,8 @@ static volatile uint32_t dio1IrqCount = 0;
 static bool        radioReady    = false;
 static bool        isTxActive    = false;
 
-// ─── Noise floor sampling (mirrors SX1262Radio._sample_noise_floor) ──
+// ─── Noise floor sampling ────────────────────────────────────
 #define NUM_NOISE_FLOOR_SAMPLES 20
-#define NOISE_SAMPLING_THRESHOLD 10
 static float    noiseFloor       = -99.0f;
 static float    noiseFloorSum    = 0.0f;
 static int      noiseFloorCount  = 0;
@@ -1569,13 +1568,13 @@ void sampleNoiseFloor() {
     if (millis() - lastNoiseSample < 10) return;
     lastNoiseSample = millis();
 
-    if (noiseFloorCount < NUM_NOISE_FLOOR_SAMPLES) {
-        float instRssi = radio.getRSSI();
-        if (instRssi < (noiseFloor + NOISE_SAMPLING_THRESHOLD)) {
-            noiseFloorCount++;
-            noiseFloorSum += instRssi;
-        }
-    } else if (noiseFloorCount >= NUM_NOISE_FLOOR_SAMPLES && noiseFloorSum != 0.0f) {
+    float instRssi = radio.getRSSI();
+    if (instRssi < -150.0f || instRssi > -30.0f) return;
+
+    noiseFloorCount++;
+    noiseFloorSum += instRssi;
+
+    if (noiseFloorCount >= NUM_NOISE_FLOOR_SAMPLES) {
         float newFloor = noiseFloorSum / NUM_NOISE_FLOOR_SAMPLES;
         if (newFloor < -150.0f) newFloor = -150.0f;
         if (newFloor > -50.0f)  newFloor = -50.0f;

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1568,7 +1568,11 @@ void sampleNoiseFloor() {
     if (millis() - lastNoiseSample < 10) return;
     lastNoiseSample = millis();
 
-    float instRssi = radio.getRSSI();
+    // RadioLib's no-arg SX126x::getRSSI() returns the last packet RSSI.
+    // For ambient/noise telemetry we must read instantaneous RSSI instead;
+    // otherwise a strong RX packet can pin the reported noise floor around
+    // that packet's RSSI until another radio state transition clears it.
+    float instRssi = radio.getRSSI(false);
     if (instRssi < -150.0f || instRssi > -30.0f) return;
 
     noiseFloorCount++;

--- a/firmware/tools/build_firmware_assets.py
+++ b/firmware/tools/build_firmware_assets.py
@@ -42,6 +42,16 @@ ENV_METADATA: dict[str, dict[str, str | bool]] = {
         "chip_family": "ESP32-S3",
         "web_manifest": True,
     },
+    "heltec_v42": {
+        "name": "Heltec WiFi LoRa 32 V4.2 pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
+    "heltec_v43": {
+        "name": "Heltec WiFi LoRa 32 V4.3 pyMC Modem",
+        "chip_family": "ESP32-S3",
+        "web_manifest": True,
+    },
     "heltec_tracker_v2": {
         "name": "Heltec Wireless Tracker V2 pyMC Modem",
         "chip_family": "ESP32-S3",
@@ -100,6 +110,8 @@ ENV_METADATA: dict[str, dict[str, str | bool]] = {
 BOARD_HEADER_TO_ENV = {
     "firmware/include/boards/heltec_v3.h": "heltec_v3",
     "firmware/include/boards/heltec_v4.h": "heltec_v4",
+    "firmware/include/boards/heltec_v42.h": "heltec_v42",
+    "firmware/include/boards/heltec_v43.h": "heltec_v43",
     "firmware/include/boards/heltec_tracker_v2.h": "heltec_tracker_v2",
     "firmware/include/boards/ikoka_stick.h": "ikoka_stick",
     "firmware/include/boards/xiao_wio_sx1262.h": "xiao_wio_sx1262",


### PR DESCRIPTION
## Summary
- Adds dedicated Heltec V4.2 and V4.3 firmware envs so each hardware revision gets the correct RF front-end policy instead of sharing the generic Heltec V4 target.
- Keeps the legacy `heltec_v4` env available while adding `heltec_v42` for GC1109/GPIO46 full-PA behavior and `heltec_v43` for KCT8103L/GPIO5 LNA-bypass behavior.
- Adds Heltec V4 GPS connector/runtime config support and includes the new envs in firmware asset metadata.
- Updates noise-floor sampling to use instantaneous idle RSSI so telemetry is not pinned by the old threshold behavior.

## Verification
- `pio run -e heltec_v42` succeeded. RAM 16.3%, flash 34.0%.
- `pio run -e heltec_v43` succeeded. RAM 16.3%, flash 34.0%.
- `pio run -e heltec_v4` succeeded. RAM 16.3%, flash 34.0%.
- `python3 firmware/tools/build_firmware_assets.py --variant heltec_v42 --plan` selected `heltec_v42`.
- `python3 firmware/tools/build_firmware_assets.py --variant heltec_v43 --plan` selected `heltec_v43`.
- `python3 firmware/tools/build_firmware_assets.py --variant all --plan` includes `heltec_v4`, `heltec_v42`, and `heltec_v43`.