### PR TITLE
firmware: bump base version to v1.0.0

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -166,8 +166,8 @@ static _WiFiStub WiFi;
 
 // ─── Version ─────────────────────────────────────────────────
 // Base version is shared by every board; the board's fw_suffix
-// distinguishes one binary from another (e.g. "v0.8.0-ikoka").
-#define FW_VERSION_BASE "v0.8.0"
+// distinguishes one binary from another (e.g. "v1.0.0-ikoka").
+#define FW_VERSION_BASE "v1.0.0"
 static String fwVersion;   // populated in setup()
 
 // ─── Task watchdog — self-heal on loop() hang ───────────────


### PR DESCRIPTION
## Summary
- Bump firmware base version from v0.8.0 to v1.0.0
- Update the inline example suffix to match the new base version

## Verification
- Ad-hoc temporary /tmp/hermes-verify-* script confirmed FW_VERSION_BASE is v1.0.0 and sampled derived manifest-style versions use the v1.0.0 prefix

Direct push to main was rejected by repository rules requiring changes through a pull request.