### PR TITLE
ci: validate cached PlatformIO executable

### DIFF
--- a/.github/workflows/build-firmware-assets.yml
+++ b/.github/workflows/build-firmware-assets.yml
@@ -133,17 +133,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v pio >/dev/null 2>&1; then
+          if command -v pio >/dev/null 2>&1 && pio --version >/dev/null 2>&1; then
             echo "PIO=$(command -v pio)" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          if [ ! -x "$GITHUB_WORKSPACE/.venv-pio/bin/pio" ]; then
+          pio_path="$GITHUB_WORKSPACE/.venv-pio/bin/pio"
+          if [ ! -x "$pio_path" ] || ! "$pio_path" --version >/dev/null 2>&1; then
+            rm -rf "$GITHUB_WORKSPACE/.venv-pio"
             python -m venv "$GITHUB_WORKSPACE/.venv-pio"
             "$GITHUB_WORKSPACE/.venv-pio/bin/python" -m pip install --upgrade pip
             "$GITHUB_WORKSPACE/.venv-pio/bin/python" -m pip install platformio
           fi
-          echo "PIO=$GITHUB_WORKSPACE/.venv-pio/bin/pio" >> "$GITHUB_ENV"
+          "$pio_path" --version
+          echo "PIO=$pio_path" >> "$GITHUB_ENV"
 
       - name: Build and stage firmware assets
         shell: bash
@@ -280,17 +283,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v pio >/dev/null 2>&1; then
+          if command -v pio >/dev/null 2>&1 && pio --version >/dev/null 2>&1; then
             echo "PIO=$(command -v pio)" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          if [ ! -x "$GITHUB_WORKSPACE/.venv-pio/bin/pio" ]; then
+          pio_path="$GITHUB_WORKSPACE/.venv-pio/bin/pio"
+          if [ ! -x "$pio_path" ] || ! "$pio_path" --version >/dev/null 2>&1; then
+            rm -rf "$GITHUB_WORKSPACE/.venv-pio"
             python -m venv "$GITHUB_WORKSPACE/.venv-pio"
             "$GITHUB_WORKSPACE/.venv-pio/bin/python" -m pip install --upgrade pip
             "$GITHUB_WORKSPACE/.venv-pio/bin/python" -m pip install platformio
           fi
-          echo "PIO=$GITHUB_WORKSPACE/.venv-pio/bin/pio" >> "$GITHUB_ENV"
+          "$pio_path" --version
+          echo "PIO=$pio_path" >> "$GITHUB_ENV"
 
       - name: Build selected firmware assets without artifact upload
         shell: bash


### PR DESCRIPTION
## Summary
- Validate both global and cached PlatformIO with `pio --version` before exporting `PIO`
- Remove and recreate `.venv-pio` when the cached executable is stale/broken
- Apply the same guard to manual matrix builds and main-push asset builds

## Why
The main push asset workflow failed because the restored `.venv-pio/bin/pio` file existed but could not be executed due to a stale cached venv/interpreter path.

## Verification
- Ad-hoc /tmp/hermes-verify-* script checked both workflow setup blocks contain the validation/removal logic
- The same script simulated a stale cached `.venv-pio/bin/pio` and confirmed the block removes/recreates it before exporting `PIO`