### PR TITLE
draft: feat(firmware): add TCP radio multiplexing

### DIFF
--- a/API.md
+++ b/API.md
@@ -114,9 +114,58 @@ Returns the combined system, radio, counters, and network state in one response.
 
 Top-level keys:
 - `system` — board, firmware, hostname, uptime, die temperature, and battery voltage only when the board variant defines battery sensing (`battery_voltage_mv`, `battery_voltage_v`; otherwise `null`)
-- `radio`
+- `radio` — live/on-air radio settings. In TCP multiplex mode it also contains `multiplexed`, `active_slot`, and `slots`; `slots` is ordered by slot number and contains only connected, authorized TCP clients
 - `counters`
 - `network`
+
+`counters.suppressed_rx` is the number of exact copies of the most recently
+transmitted packet discarded during the configured TX echo suppression window.
+Suppressed packets are not included in `counters.rx_packets` and are not
+sent to radio slots.
+
+In multiplex mode, each `radio.slots[]` entry contains the TCP slot identity and
+all per-slot radio/CAD settings in a stable order:
+
+```json
+{
+  "slot": 0,
+  "port": 5055,
+  "active": true,
+  "on_air": true,
+  "standby": false,
+  "client_ip": "192.168.1.10",
+  "recieve_mirroing": [1],
+  "auto_cad_enabled": false,
+  "cad_custom": true,
+  "cad_sym_num": 1,
+  "cad_det_peak": 22,
+  "cad_det_min": 10,
+  "cad_exit_mode": 0,
+  "frequency_hz": 869618000,
+  "frequency_mhz": 869.618,
+  "bandwidth_hz": 62500,
+  "bandwidth_khz": 62.5,
+  "spreading_factor": 8,
+  "coding_rate": 8,
+  "tx_power_dbm": 22,
+  "syncword": "0x12",
+  "syncword_value": 18,
+  "preamble_len": 16
+}
+```
+
+`radio.slots[].recieve_mirroing` lists the other connected, non-standby slots
+that can receive the same packets as this slot. Matching compares only receive
+parameters: frequency, bandwidth, spreading factor, coding rate, and syncword.
+CAD settings, TX power, preamble length, status, TCP port, and client identity
+are ignored. Each packet/profile pair is delivered at most once to each ready
+slot during the duplicate-suppression window, so a client echo cannot cause the
+same packet to be mirrored back and forth. The field is an empty array when no
+other slot mirrors the receive profile.
+
+`radio.active_slot` is the slot currently selected by the receive scheduler,
+or `null` while no slot is on air. When no TCP client is connected, `radio.slots` is an empty array and the
+existing live radio fields remain unchanged.
 
 ### `GET /api/config`
 
@@ -130,6 +179,9 @@ Example:
   "effective_hostname": "heltec-ab12cd",
   "tcp_token": "your-token",
   "tcp_port": 5055,
+  "rx_slot_ms": 100,
+  "activity_hold_ms": 2000,
+  "tx_echo_hold_multiplier": 1,
   "use_static_ip": true,
   "static_ip": "192.168.1.42",
   "subnet": "255.255.255.0",
@@ -147,8 +199,20 @@ Accepted top-level fields:
 - `hostname`
 - `tcp_token`
 - `tcp_port`
+- `rx_slot_ms`
+- `activity_hold_ms`
+- `tx_echo_hold_multiplier`
 - `use_static_ip`
 - `network`
+
+Multiplexing fields:
+- `rx_slot_ms` — receive-slot dwell in milliseconds; minimum `5`
+- `activity_hold_ms` — how long to retain a slot after CAD detects activity or
+  an RF packet is received; queued TX requests wait for the hold to expire, and
+  `0` disables the hold
+- `tx_echo_hold_multiplier` — suppress an exact RF copy of the most recently
+  completed TX for `activity_hold_ms × tx_echo_hold_multiplier`; default `1`,
+  and `0` disables TX reflection suppression
 
 `network` fields:
 - `use_static_ip`
@@ -173,6 +237,9 @@ curl -u admin:YOUR_PASSWORD \
   -d '{
     "hostname": "heltec-ab12cd",
     "tcp_token": "meshpass",
+    "rx_slot_ms": 100,
+    "activity_hold_ms": 2000,
+    "tx_echo_hold_multiplier": 1,
     "network": {
       "use_static_ip": true,
       "static_ip": "192.168.1.42",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -266,6 +266,35 @@ pymc_tcp:
   lbt_max_attempts: 5
 ```
 
+For four wire-compatible virtual radios, use the configured port and the next
+three consecutive ports (`5055`–`5058` in this example). Each client connects
+to one port and sends the same existing protocol; no protocol version or frame
+field changes are required. The modem keeps connected TCP sessions open while
+switching the single physical radio, and skips listener slots that have no
+active authorized client. TX is serialized with priority over RX rotation.
+
+The device HTTP page's **TCP Multiplexing** section and `POST /api/config` can
+change the scheduler at runtime. The API fields are `rx_slot_ms` (minimum 5 ms),
+`activity_hold_ms` (0 disables the hold), and `tx_echo_hold_multiplier` (default
+1; 0 disables exact last-TX reflection suppression). Firmware build flags remain
+available as first-boot defaults:
+
+```ini
+build_flags =
+  -DPYMC_RX_SLOT_MS=100       ; valid range: 5 ms and above
+  -DPYMC_ACTIVITY_HOLD_MS=2000
+```
+
+At 5 ms, CAD is skipped for slot rotation because its SX1262 operation can be
+longer than the requested dwell; TX and explicit host CAD still remain
+functional. Treat receive coverage as best effort at short dwell values.
+
+The RAK4631/W5100S target is the exception to the four-port layout: it exposes
+only the configured base port (normally `5055`) and one TCP client. The W5100S
+has four hardware sockets total, and using four listeners would consume the
+socket budget before accepted protocol clients could operate. Use an ESP32
+Wi-Fi target when four simultaneous TCP virtual radios are required.
+
 USB modem alternative:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # openHop Modem (`pymc_modem`) — USB/TCP LoRa modem for openHop Core
 
 Firmware + Python driver that turns a supported ESP32 or nRF52 board
@@ -58,6 +59,59 @@ Raspberry Pi                                  openHop Modem
   token defaults blank/open on fresh firmware and can be set from the web UI on
   web-enabled builds. The RAK4631 Ethernet variant has no web UI/HTTP stack, so
   its W5100S TCP defaults live in `PYMC_ETH_*` build flags.
+
+### TCP virtual-radio multiplexing
+
+Network firmware keeps the existing openHop TCP frame protocol unchanged. When
+multiplexing is enabled, the configured protocol port is slot 0 and the modem
+also listens on the next three ports: for base port `5055`, slots use `5055`,
+`5056`, `5057`, and `5058`. Each port accepts one persistent client and uses the
+same TCP token. Radio profiles are independent per port; `CMD_SET_CONFIG`, CAD
+parameters, standby/resume, and TX completion are routed to the originating
+port without adding a slot field to any frame. RX packets are sent once to
+each ready, non-standby client whose receive-relevant settings match the active
+slot; TX power, preamble, CAD settings, and connection metadata do not affect
+that matching. A short-lived packet/profile cache suppresses repeated fan-out
+when a mirrored client echoes the same packet back over the air.
+
+The radio performs cooperative round-robin receive scheduling **only across
+connected, authorized TCP slots**; configured listeners without a client are
+skipped. Default dwell is 100 ms, configurable from the device HTTP page or
+`/api/config` with `rx_slot_ms` down to a validated minimum of 50 ms.
+`activity_hold_ms` controls bounded retention after slot CAD detects activity or
+the radio receives a packet. Queued TX requests remain queued during this hold
+and cannot take over the radio until it expires. The setting is validated for US
+Meshcore settings down to 1000ms (Max packet transmit time is 800ms theoretically).
+
+`tx_echo_hold_multiplier` defaults to 1. An exact RF copy of the last successfully
+transmitted packet is discarded for `activity_hold_ms` multiplied by this value,
+before RX counters or slot mirroring; set the multiplier to 0 to disable it.
+
+The legacy build flags
+`PYMC_RX_SLOT_MS` and `PYMC_ACTIVITY_HOLD_MS` still provide first-boot defaults.
+After any activity hold expires, TX requests have priority over RX rotation and
+are serialized fairly across ports; sockets stay connected while the radio changes
+profile, performs CAD, or transmits. At very short dwell values, SPI profile
+switch and CAD latency can exceed the requested wall-clock dwell, so actual
+observation time is best effort and packet loss remains possible.
+
+The RAK4631/W5100S Ethernet target is intentionally limited to slot 0 on the
+base port (normally `5055`). The W5100S exposes only four hardware sockets, so
+reserving sockets for multiple listeners would leave no reliable socket for an
+accepted protocol client. Wi-Fi ESP32 targets provide the four-port
+(`5055`–`5058`) service; W5100S remains a single-client Ethernet transport.
+
+Example PlatformIO override:
+
+```ini
+build_flags =
+  -DPYMC_RX_SLOT_MS=50
+  -DPYMC_ACTIVITY_HOLD_MS=2000
+```
+
+Single-client deployments remain compatible: connect to the base port only and
+use the normal [`TCPLoRaRadio`](pymc_driver/tcp_radio.py) configuration with that
+port.
 
 ## Project layout
 

--- a/firmware/include/runtime_stats.h
+++ b/firmware/include/runtime_stats.h
@@ -5,8 +5,29 @@
 
 namespace RuntimeStats {
 
+constexpr uint8_t MAX_VIRTUAL_RADIO_SLOTS = 4;
+
+struct VirtualSlotSnapshot {
+    uint8_t slot;
+    uint16_t port;
+    bool active;
+    bool onAir;
+    bool standby;
+    bool autoCadEnabled;
+    bool cadCustom;
+    uint8_t cadSymNum;
+    uint8_t cadDetPeak;
+    uint8_t cadDetMin;
+    uint8_t cadExitMode;
+    RadioConfig radio;
+    String clientIP;
+    uint8_t receiveMirroringCount;
+    uint8_t receiveMirroring[MAX_VIRTUAL_RADIO_SLOTS];
+};
+
 struct Snapshot {
     StatusResp status;
+    uint32_t suppressedRxCount;
     RadioConfig radio;
     String firmwareVersion;
     bool radioStandby;
@@ -14,6 +35,8 @@ struct Snapshot {
     bool hasBatteryChargeRatePctPerHour;
     bool batteryChargeRatePctPerHourValid;
     float batteryChargeRatePctPerHour;
+    uint8_t virtualSlotCount;
+    VirtualSlotSnapshot virtualSlots[MAX_VIRTUAL_RADIO_SLOTS];
 };
 
 Snapshot capture();

--- a/firmware/include/tcp_server.h
+++ b/firmware/include/tcp_server.h
@@ -1,7 +1,7 @@
 // =============================================================
 // tcp_server.h — TCP LoRa-modem protocol server (Wi-Fi STA)
-// Accepts one client; optional shared-token auth required before
-// non-AUTH commands are processed.
+// Accepts one client per listener; optional shared-token auth is
+// required before non-AUTH commands are processed.
 // =============================================================
 #pragma once
 
@@ -10,10 +10,13 @@
 
 namespace TCPServer {
 
-// Start (or restart) the server. Call after WiFi STA is up.
+constexpr uint8_t MAX_TCP_CLIENTS = 4;
+
+// Start (or restart) the server. Call after WiFi STA is up. Returns false
+// when the requested base port cannot accommodate every listener slot.
 // If token.length() > 0, clients must send CMD_AUTH with matching
 // payload before any other command is accepted.
-void begin(uint16_t port, const String& token);
+bool begin(uint16_t port, const String& token);
 
 // Stop accepting connections and drop the current client.
 void end();
@@ -24,10 +27,22 @@ void loop();
 // True when a client is connected AND (authenticated OR no token required).
 bool isClientReady();
 
+// Current command slot while dispatching, otherwise the first ready slot
+// (or first connected slot when none are ready), or 0xFF when no client exists.
+uint8_t activeSlot();
+bool isSlotReady(uint8_t slot);
+uint32_t getSlotGeneration(uint8_t slot);
+
 // Dotted quad of the connected client, or empty string when no client.
 String getClientIP();
+String getSlotIP(uint8_t slot);
 
-// Queue bytes to connected client; no-op if no client.
+// Queue bytes to the current command client, or all ready clients otherwise.
 void write(const uint8_t* data, size_t len);
+void writeToSlot(uint8_t slot, const uint8_t* data, size_t len);
+void writeToReadySlots(const uint8_t* data, size_t len);
+
+// Returns the listener slot associated with the current frame callback.
+uint8_t currentCommandSlot();
 
 } // namespace TCPServer

--- a/firmware/include/w5100s_ethernet_transport.h
+++ b/firmware/include/w5100s_ethernet_transport.h
@@ -6,6 +6,7 @@
 
 #include <Arduino.h>
 #include <IPAddress.h>
+#include "tcp_server.h"
 
 namespace EthernetManager {
     void begin(const char* hostname = nullptr,
@@ -20,13 +21,4 @@ namespace EthernetManager {
     bool isLinkUp();
     bool hasIP();
     const char* getIPString();
-}
-
-namespace TCPServer {
-    void begin(uint16_t port, const String& token);
-    void loop();
-    void end();
-    bool isClientReady();
-    void write(const uint8_t* data, size_t len);
-    String getClientIP();
 }

--- a/firmware/include/wifi_manager.h
+++ b/firmware/include/wifi_manager.h
@@ -9,6 +9,21 @@
 
 namespace WifiManager {
 
+constexpr uint32_t MIN_RX_SLOT_MS = 5;
+constexpr uint32_t DEFAULT_RX_SLOT_MS = 100;
+constexpr uint32_t DEFAULT_ACTIVITY_HOLD_MS = 2000;
+
+#ifndef PYMC_RX_SLOT_MS
+#  define PYMC_RX_SLOT_MS DEFAULT_RX_SLOT_MS
+#endif
+#ifndef PYMC_ACTIVITY_HOLD_MS
+#  define PYMC_ACTIVITY_HOLD_MS DEFAULT_ACTIVITY_HOLD_MS
+#endif
+
+constexpr uint32_t BUILD_DEFAULT_RX_SLOT_MS =
+    (PYMC_RX_SLOT_MS < MIN_RX_SLOT_MS) ? MIN_RX_SLOT_MS : (uint32_t)PYMC_RX_SLOT_MS;
+constexpr uint32_t BUILD_DEFAULT_ACTIVITY_HOLD_MS = (uint32_t)PYMC_ACTIVITY_HOLD_MS;
+
 enum class Mode : uint8_t {
     OFFLINE        = 0,
     STA_CONNECTING = 1,
@@ -30,6 +45,9 @@ struct Config {
     uint16_t  tcpPort;   // default 5055
     bool      wifiExternalAntenna; // C6-only when BOARD enables antenna switch
     bool      gpsEnabled; // default off; applies to any board with GPS UART pins
+    uint32_t  rxSlotMs = BUILD_DEFAULT_RX_SLOT_MS;
+    uint32_t  activityHoldMs = BUILD_DEFAULT_ACTIVITY_HOLD_MS;
+    uint32_t  txEchoHoldMultiplier = 1;
 };
 
 // Poll PRG button at boot; if held >= 3s, wipe NVS and reboot. Call from setup().

--- a/firmware/src/config_portal.cpp
+++ b/firmware/src/config_portal.cpp
@@ -7,6 +7,7 @@
 
 #include <WebServer.h>
 #include <WiFi.h>
+#include <cstdlib>
 
 namespace ConfigPortal {
 
@@ -146,6 +147,14 @@ static void handleRoot() {
     html += F("<label>TCP auth token <span class='hint'>(optional; empty = no auth)</span></label>");
     html += "<input type='text' name='token' autocomplete='off' value='" + htmlEscape(cfg.tcpToken) + "'>";
 
+    html += F("<hr><label>TCP multiplexing</label>");
+    html += F("<label>RX slot dwell (ms) <span class='hint'>(minimum 5)</span></label>");
+    html += "<input type='number' name='rx_slot_ms' min='5' max='4294967295' step='1' value='" + String(cfg.rxSlotMs) + "'>";
+    html += F("<label>Activity hold (ms) <span class='hint'>(0 disables)</span></label>");
+    html += "<input type='number' name='activity_hold_ms' min='0' max='4294967295' step='1' value='" + String(cfg.activityHoldMs) + "'>";
+    html += F("<label>TX echo hold multiplier <span class='hint'>(default 1; 0 disables)</span></label>");
+    html += "<input type='number' name='tx_echo_hold_multiplier' min='0' max='4294967295' step='1' value='" + String(cfg.txEchoHoldMultiplier) + "'>";
+
     html += F("<button type='submit'>Save &amp; Restart</button>");
     html += F("</form></body></html>");
 
@@ -157,6 +166,18 @@ static IPAddress parseIP(const String& s) {
     IPAddress ip;
     if (!ip.fromString(s)) ip = IPAddress((uint32_t)0);
     return ip;
+}
+
+static bool parseUint32(const String& rawValue, uint32_t& output) {
+    String raw = rawValue;
+    raw.trim();
+    if (raw.length() == 0) return false;
+
+    char* end = nullptr;
+    unsigned long long parsed = strtoull(raw.c_str(), &end, 10);
+    if (end == raw.c_str() || *end != '\0' || parsed > 0xFFFFFFFFULL) return false;
+    output = (uint32_t)parsed;
+    return true;
 }
 
 static void handleSave() {
@@ -186,6 +207,23 @@ static void handleSave() {
     newCfg.tcpToken    = server->arg("token");
     newCfg.hostname    = server->arg("hostname");
     newCfg.hostname.trim();
+
+    uint32_t rxSlotMs = 0;
+    if (!parseUint32(server->arg("rx_slot_ms"), rxSlotMs) ||
+        rxSlotMs < WifiManager::MIN_RX_SLOT_MS) {
+        rxSlotMs = WifiManager::BUILD_DEFAULT_RX_SLOT_MS;
+    }
+    newCfg.rxSlotMs = rxSlotMs;
+    uint32_t activityHoldMs = 0;
+    if (!parseUint32(server->arg("activity_hold_ms"), activityHoldMs)) {
+        activityHoldMs = WifiManager::BUILD_DEFAULT_ACTIVITY_HOLD_MS;
+    }
+    newCfg.activityHoldMs = activityHoldMs;
+    uint32_t txEchoHoldMultiplier = 1;
+    if (!parseUint32(server->arg("tx_echo_hold_multiplier"), txEchoHoldMultiplier)) {
+        txEchoHoldMultiplier = 1;
+    }
+    newCfg.txEchoHoldMultiplier = txEchoHoldMultiplier;
 
     int port = server->arg("port").toInt();
     if (port < 1 || port > 65535) port = 5055;

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -77,6 +77,9 @@ namespace WifiManager {
         uint16_t tcpPort = 0;
         bool     wifiExternalAntenna = false;
         bool     gpsEnabled = false;
+        uint32_t rxSlotMs = 100;
+        uint32_t activityHoldMs = 2000;
+        uint32_t txEchoHoldMultiplier = 1;
     };
     inline void  checkResetButton()  {}
     inline void  begin()             {}
@@ -113,7 +116,7 @@ namespace WifiManager {
 #  include "w5100s_ethernet_transport.h"
 #else
 namespace TCPServer {
-    inline void begin(uint16_t, const String&) {}
+    inline bool begin(uint16_t, const String&) { return true; }
     inline void loop() {}
     inline void end()  {}
     inline bool isClientReady() { return false; }
@@ -140,6 +143,16 @@ namespace EthernetManager {
     inline bool isLinkUp() { return false; }
     inline bool hasIP()    { return false; }
     inline const char* getIPString() { return "---"; }
+}
+#endif
+#if !defined(ARDUINO_ARCH_ESP32) && !defined(PYMC_ETHERNET_W5100S)
+namespace TCPServer {
+    inline uint8_t currentCommandSlot() { return 0xFF; }
+    inline uint8_t activeSlot() { return 0xFF; }
+    inline bool isSlotReady(uint8_t) { return false; }
+    inline uint32_t getSlotGeneration(uint8_t) { return 0; }
+    inline String getSlotIP(uint8_t) { return String(); }
+    inline void writeToSlot(uint8_t, const uint8_t*, size_t) {}
 }
 #endif
 // Per-board display driver on nRF52 boards. T114 ships with an
@@ -224,12 +237,101 @@ static RadioConfig currentConfig = {
     .preamble_len = 16
 };
 
+// TCP keeps wire compatibility by giving each virtual modem its own port.
+// Profiles live here, not in the transport, so Wi-Fi and W5100S scheduling
+// share exactly the same radio policy. Slot 0 remains the legacy 5055 port.
+static constexpr uint8_t VIRTUAL_SLOT_COUNT = 4;
+static constexpr uint8_t INVALID_VIRTUAL_SLOT = 0xFF;
+static bool radioStandby = false;
+static RadioConfig virtualConfigs[VIRTUAL_SLOT_COUNT];
+static bool virtualConfigsInitialized = false;
+static bool virtualStandby[VIRTUAL_SLOT_COUNT] = {};
+static uint8_t activeVirtualSlot = INVALID_VIRTUAL_SLOT;
+static uint32_t activeVirtualGeneration = 0;
+
+// A packet echoed by one of the virtual-radio clients can be received again
+// while the scheduler is visiting another matching slot.  Keep a short-lived
+// exact-payload cache so that an RF echo is treated as the same packet rather
+// than as a new packet to mirror to every client again.
+static constexpr uint8_t RECENT_RX_PACKET_CACHE_SIZE = 8;
+static constexpr uint32_t RECENT_RX_PACKET_TTL_MS = 5000;
+struct RecentRxPacket {
+    bool valid = false;
+    uint16_t len = 0;
+    uint32_t seenMs = 0;
+    uint8_t data[MAX_LORA_PAYLOAD] = {};
+    uint32_t freq_hz = 0;
+    uint32_t bandwidth_hz = 0;
+    uint8_t sf = 0;
+    uint8_t cr = 0;
+    uint16_t syncword = 0;
+    uint8_t deliveredSlots = 0;
+    uint32_t deliveredGenerations[VIRTUAL_SLOT_COUNT] = {};
+};
+static RecentRxPacket recentRxPackets[RECENT_RX_PACKET_CACHE_SIZE];
+static uint8_t recentRxPacketCursor = 0;
+
+struct LastTransmittedPacket {
+    bool valid = false;
+    uint16_t len = 0;
+    uint32_t completedMs = 0;
+    uint8_t data[MAX_LORA_PAYLOAD] = {};
+};
+static LastTransmittedPacket lastTransmittedPacket;
+
+static constexpr uint32_t DEFAULT_RX_SLOT_MS = 100;
+static constexpr uint32_t MIN_RX_SLOT_MS = 5;
+static constexpr uint32_t DEFAULT_ACTIVITY_HOLD_MS = 2000;
+#ifndef PYMC_RX_SLOT_MS
+#  define PYMC_RX_SLOT_MS DEFAULT_RX_SLOT_MS
+#endif
+#ifndef PYMC_ACTIVITY_HOLD_MS
+#  define PYMC_ACTIVITY_HOLD_MS DEFAULT_ACTIVITY_HOLD_MS
+#endif
+static uint32_t rxSlotDurationMs =
+    (PYMC_RX_SLOT_MS < MIN_RX_SLOT_MS) ? MIN_RX_SLOT_MS : (uint32_t)PYMC_RX_SLOT_MS;
+static uint32_t activityHoldMs = (uint32_t)PYMC_ACTIVITY_HOLD_MS;
+static uint32_t txEchoHoldMultiplier = 1;
+static uint32_t rxSlotStartedMs = 0;
+static uint32_t activityHoldUntilMs = 0;
+static uint8_t nextVirtualSlot = 0;
+
+struct PendingVirtualTx {
+    bool pending = false;
+    uint16_t len = 0;
+    uint8_t data[MAX_LORA_PAYLOAD] = {};
+};
+static PendingVirtualTx virtualTx[VIRTUAL_SLOT_COUNT];
+static uint32_t virtualTxGeneration[VIRTUAL_SLOT_COUNT] = {};
+static uint8_t nextTxSlot = 0;
+static uint8_t txOwnerSlot = INVALID_VIRTUAL_SLOT;
+static uint32_t txOwnerGeneration = 0;
+static uint32_t txStartedMs = 0;
+
+enum class VirtualRadioOperation : uint8_t {
+    RX_SLOT,
+    CAD_FOR_SLOT,
+    CAD_FOR_HOST,
+    CAD_FOR_TX,
+    TX
+};
+enum class VirtualCadStartResult : uint8_t {
+    STARTED,
+    BUSY,
+    FAILED
+};
+static VirtualRadioOperation virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+static uint8_t cadOwnerSlot = INVALID_VIRTUAL_SLOT;
+static uint32_t cadOwnerGeneration = 0;
+static uint32_t cadStartedMs = 0;
+static bool cadResponsePending = false;
+
 static StatusResp  status        = {};
+static uint32_t suppressedRxCount = 0;
 // Hard-standby flag set by CMD_RADIO_STANDBY. While true, loop()
 // will NOT call startReceive() after a TX/CAD/RX completion, and
 // the radio sits in idle. Cleared by CMD_RADIO_RESUME (which
 // re-applies the config and re-enters RX).
-static bool radioStandby  = false;
 static bool autoCadEnabled = false;   // pre-TX CAD; enabled via CMD_SET_AUTO_CAD, persisted in NodeState
 
 // Single DIO1 ISR flag — interpreted as RX_DONE when !isTxActive, otherwise as TX_DONE.
@@ -257,6 +359,26 @@ static uint8_t cadSymNum   = 0x01;  // RADIOLIB_SX126X_CAD_ON_2_SYMB — matches
 static uint8_t cadDetPeak  = 22;    // pymc_core default for SF7-SF8
 static uint8_t cadDetMin   = 10;    // AN1200.48 recommendation
 static uint8_t cadExitMode = 0x00;  // RADIOLIB_SX126X_CAD_GOTO_STDBY
+static bool    virtualCadCustom[VIRTUAL_SLOT_COUNT] = {};
+static uint8_t virtualCadSymNum[VIRTUAL_SLOT_COUNT] = {};
+static uint8_t virtualCadDetPeak[VIRTUAL_SLOT_COUNT] = {};
+static uint8_t virtualCadDetMin[VIRTUAL_SLOT_COUNT] = {};
+static uint8_t virtualCadExitMode[VIRTUAL_SLOT_COUNT] = {};
+
+static bool radioConfigsMatch(const RadioConfig& lhs, const RadioConfig& rhs);
+
+static void initializeVirtualConfigs() {
+    if (virtualConfigsInitialized) return;
+    for (uint8_t i = 0; i < VIRTUAL_SLOT_COUNT; ++i) {
+        virtualConfigs[i] = currentConfig;
+        virtualCadCustom[i] = cadCustom;
+        virtualCadSymNum[i] = cadSymNum;
+        virtualCadDetPeak[i] = cadDetPeak;
+        virtualCadDetMin[i] = cadDetMin;
+        virtualCadExitMode[i] = cadExitMode;
+    }
+    virtualConfigsInitialized = true;
+}
 
 // ─── Transport state ─────────────────────────────────────────
 static FrameParser serialParser;
@@ -387,12 +509,58 @@ namespace RuntimeStats {
 Snapshot capture() {
     Snapshot snap = {};
     snap.status = status;
+    snap.suppressedRxCount = suppressedRxCount;
     snap.status.uptime_sec = millis() / 1000;
     snap.status.radio_state = radioStandby ? 2 : (isTxActive ? 1 : 0);
     snap.status.temp_c = (int8_t)temperatureRead();
     snap.status.noise_floor_x10 = (int16_t)(noiseFloor * 10.0f);
     snap.status.battery_mv = readBatteryMilliVolts();
+    if (TCPServer::isClientReady()) initializeVirtualConfigs();
     snap.radio = currentConfig;
+    snap.virtualSlotCount = 0;
+    for (uint8_t i = 0; i < VIRTUAL_SLOT_COUNT; ++i) {
+        if (!TCPServer::isSlotReady(i)) continue;
+
+        VirtualSlotSnapshot& virtualSlot = snap.virtualSlots[snap.virtualSlotCount++];
+        virtualSlot.slot = i;
+        virtualSlot.port = (uint16_t)(WifiManager::getConfig().tcpPort + i);
+        virtualSlot.active = true;
+        virtualSlot.onAir = activeVirtualSlot == i;
+        virtualSlot.standby = virtualStandby[i];
+        virtualSlot.autoCadEnabled = autoCadEnabled;
+        virtualSlot.cadCustom = virtualCadCustom[i];
+        virtualSlot.cadSymNum = virtualCadSymNum[i] ? virtualCadSymNum[i] : 0x01;
+        virtualSlot.cadDetPeak = virtualCadDetPeak[i] ? virtualCadDetPeak[i] : 22;
+        virtualSlot.cadDetMin = virtualCadDetMin[i] ? virtualCadDetMin[i] : 10;
+        virtualSlot.cadExitMode = virtualCadExitMode[i];
+        virtualSlot.radio = virtualConfigs[i];
+        virtualSlot.clientIP = TCPServer::getSlotIP(i);
+        virtualSlot.receiveMirroringCount = 0;
+
+        // Keep the legacy single-radio fields useful for API consumers that
+        // have not learned about radio.slots yet: report the on-air
+        // profile, or the first connected profile while the scheduler starts.
+        if (virtualSlot.onAir || snap.virtualSlotCount == 1) {
+            snap.radio = virtualSlot.radio;
+        }
+    }
+
+    // A packet received while one profile is on air is fanned out to every
+    // ready, non-standby slot with the same receive parameters.  TX-only
+    // settings and connection/UI state are deliberately excluded from this
+    // relationship; they do not affect whether a slot can receive the packet.
+    for (uint8_t i = 0; i < snap.virtualSlotCount; ++i) {
+        VirtualSlotSnapshot& slot = snap.virtualSlots[i];
+
+        for (uint8_t j = 0; j < snap.virtualSlotCount; ++j) {
+            const VirtualSlotSnapshot& other = snap.virtualSlots[j];
+            if (i == j || slot.standby || other.standby ||
+                !radioConfigsMatch(slot.radio, other.radio)) {
+                continue;
+            }
+            slot.receiveMirroring[slot.receiveMirroringCount++] = other.slot;
+        }
+    }
     snap.firmwareVersion = fwVersion;
     snap.radioStandby = radioStandby;
     snap.autoCadEnabled = autoCadEnabled;
@@ -792,6 +960,575 @@ bool startReceive() {
     return radio.startReceive() == RADIOLIB_ERR_NONE;
 }
 
+static uint8_t tcpCommandSlot() {
+    uint8_t slot = TCPServer::currentCommandSlot();
+    return slot < VIRTUAL_SLOT_COUNT ? slot : INVALID_VIRTUAL_SLOT;
+}
+
+static bool virtualTcpReady() {
+    for (uint8_t slot = 0; slot < VIRTUAL_SLOT_COUNT; ++slot) {
+        if (TCPServer::isSlotReady(slot)) return true;
+    }
+    return false;
+}
+
+// A listener is not a radio session.  Only an established, authorized TCP
+// connection may participate in receive rotation; otherwise the modem would
+// spend a dwell on every configured port even when most virtual radios are
+// unused.  Keep this check in one helper so every scheduler entry point uses
+// the same eligibility policy.
+static bool virtualSlotEligible(uint8_t slot) {
+    return slot < VIRTUAL_SLOT_COUNT &&
+           !virtualStandby[slot] &&
+           TCPServer::isSlotReady(slot);
+}
+
+static bool virtualSessionCurrent(uint8_t slot, uint32_t generation) {
+    return slot < VIRTUAL_SLOT_COUNT &&
+           TCPServer::isSlotReady(slot) &&
+           TCPServer::getSlotGeneration(slot) == generation;
+}
+
+static bool radioConfigsMatch(const RadioConfig& lhs, const RadioConfig& rhs) {
+    // Compare only receive-relevant fields.  CAD settings, TX power, and
+    // preamble length are intentionally ignored: they do not change the
+    // receive profile used for RX packet mirroring.
+    return lhs.freq_hz == rhs.freq_hz &&
+           lhs.bandwidth_hz == rhs.bandwidth_hz &&
+           lhs.sf == rhs.sf &&
+           lhs.cr == rhs.cr &&
+           lhs.syncword == rhs.syncword;
+}
+
+static bool virtualRadioOwnershipCommand(uint8_t cmd) {
+    switch (cmd) {
+    case CMD_TX_REQUEST:
+    case CMD_CAD_REQUEST:
+    case CMD_RX_START:
+    case CMD_SET_CONFIG:
+    case CMD_SET_CAD_PARAMS:
+    case CMD_SET_AUTO_CAD:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool beginVirtualProfile(uint8_t slot) {
+    if (radioStandby || !virtualSlotEligible(slot)) return false;
+    if (!virtualConfigsInitialized) {
+        for (uint8_t i = 0; i < VIRTUAL_SLOT_COUNT; ++i) {
+            virtualConfigs[i] = currentConfig;
+            virtualCadCustom[i] = cadCustom;
+            virtualCadSymNum[i] = cadSymNum;
+            virtualCadDetPeak[i] = cadDetPeak;
+            virtualCadDetMin[i] = cadDetMin;
+            virtualCadExitMode[i] = cadExitMode;
+        }
+        virtualConfigsInitialized = true;
+    }
+    if (activeVirtualSlot == slot) {
+        activeVirtualGeneration = TCPServer::getSlotGeneration(slot);
+        return true;
+    }
+    cadCustom = virtualCadCustom[slot];
+    cadSymNum = virtualCadSymNum[slot] ? virtualCadSymNum[slot] : 0x01;
+    cadDetPeak = virtualCadDetPeak[slot] ? virtualCadDetPeak[slot] : 22;
+    cadDetMin = virtualCadDetMin[slot] ? virtualCadDetMin[slot] : 10;
+    cadExitMode = virtualCadExitMode[slot];
+    if (!applyConfig(virtualConfigs[slot])) return false;
+    activeVirtualSlot = slot;
+    activeVirtualGeneration = TCPServer::getSlotGeneration(slot);
+    rxSlotStartedMs = millis();
+    activityHoldUntilMs = 0;
+    virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+    return startReceive();
+}
+
+static void sendFrameToVirtualSlot(uint8_t slot, uint8_t cmd,
+                                   const uint8_t* payload, uint16_t len) {
+    if (slot >= VIRTUAL_SLOT_COUNT || !TCPServer::isSlotReady(slot)) return;
+    uint8_t buf[MAX_FRAME_SIZE];
+    uint16_t i = 0;
+    buf[i++] = PROTO_SYNC;
+    buf[i++] = cmd;
+    buf[i++] = len & 0xFF;
+    buf[i++] = (len >> 8) & 0xFF;
+    if (len && payload) {
+        memcpy(buf + i, payload, len);
+        i += len;
+    }
+    uint16_t crc = crc16_ccitt(buf + 1, 3 + len);
+    buf[i++] = crc & 0xFF;
+    buf[i++] = (crc >> 8) & 0xFF;
+    TCPServer::writeToSlot(slot, buf, i);
+}
+
+static void sendFrameToVirtualSlotGeneration(uint8_t slot, uint32_t generation,
+                                               uint8_t cmd, const uint8_t* payload,
+                                               uint16_t len) {
+    if (slot >= VIRTUAL_SLOT_COUNT ||
+        TCPServer::getSlotGeneration(slot) != generation) return;
+    sendFrameToVirtualSlot(slot, cmd, payload, len);
+}
+
+static bool sendRxPacketToMatchingVirtualSlots(const uint8_t* payload,
+                                                uint16_t len) {
+    if (activeVirtualSlot >= VIRTUAL_SLOT_COUNT ||
+        !virtualSessionCurrent(activeVirtualSlot, activeVirtualGeneration) ||
+        !payload || len < 6 || len - 6 > MAX_LORA_PAYLOAD) {
+        return false;
+    }
+
+    const RadioConfig& activeConfig = virtualConfigs[activeVirtualSlot];
+    uint8_t matchingSlots = 0;
+    for (uint8_t slot = 0; slot < VIRTUAL_SLOT_COUNT; ++slot) {
+        if (!virtualSlotEligible(slot) ||
+            !radioConfigsMatch(virtualConfigs[slot], activeConfig)) {
+            continue;
+        }
+        matchingSlots |= (uint8_t)(1U << slot);
+    }
+    if (matchingSlots == 0) return false;
+
+    // One physical packet is delivered once to the source slot and once to
+    // each matching partner. Exact RF payload bytes and receive profile form
+    // the duplicate key; the modem does not interpret the mesh packet format.
+    const uint8_t* loraPayload = payload + 6;
+    const uint16_t loraLen = len - 6;
+    const uint32_t now = millis();
+    RecentRxPacket* recentMatch = nullptr;
+    for (uint8_t i = 0; i < RECENT_RX_PACKET_CACHE_SIZE; ++i) {
+        RecentRxPacket& recent = recentRxPackets[i];
+        if (!recent.valid || recent.len != loraLen ||
+            (uint32_t)(now - recent.seenMs) >= RECENT_RX_PACKET_TTL_MS ||
+            recent.freq_hz != activeConfig.freq_hz ||
+            recent.bandwidth_hz != activeConfig.bandwidth_hz ||
+            recent.sf != activeConfig.sf || recent.cr != activeConfig.cr ||
+            recent.syncword != activeConfig.syncword ||
+            memcmp(recent.data, loraPayload, loraLen) != 0) {
+            continue;
+        }
+        recentMatch = &recent;
+        break;
+    }
+
+    if (!recentMatch) {
+        recentMatch = &recentRxPackets[recentRxPacketCursor];
+        recentMatch->valid = true;
+        recentMatch->len = loraLen;
+        memcpy(recentMatch->data, loraPayload, loraLen);
+        recentMatch->freq_hz = activeConfig.freq_hz;
+        recentMatch->bandwidth_hz = activeConfig.bandwidth_hz;
+        recentMatch->sf = activeConfig.sf;
+        recentMatch->cr = activeConfig.cr;
+        recentMatch->syncword = activeConfig.syncword;
+        recentMatch->seenMs = now;
+        recentMatch->deliveredSlots = 0;
+        for (uint8_t slot = 0; slot < VIRTUAL_SLOT_COUNT; ++slot) {
+            recentMatch->deliveredGenerations[slot] = 0;
+        }
+        recentRxPacketCursor = (uint8_t)((recentRxPacketCursor + 1) %
+                                         RECENT_RX_PACKET_CACHE_SIZE);
+    }
+    // Use a sliding expiry. Continuous echoes keep this entry alive and can
+    // never restart the fan-out; a genuinely repeated packet is accepted only
+    // after the channel has been quiet for the full suppression interval.
+    recentMatch->seenMs = now;
+    uint8_t undeliveredSlots = 0;
+    for (uint8_t slot = 0; slot < VIRTUAL_SLOT_COUNT; ++slot) {
+        const uint8_t bit = (uint8_t)(1U << slot);
+        if ((matchingSlots & bit) != 0 &&
+            ((recentMatch->deliveredSlots & bit) == 0 ||
+             recentMatch->deliveredGenerations[slot] !=
+                 TCPServer::getSlotGeneration(slot))) {
+            undeliveredSlots |= bit;
+        }
+    }
+    for (uint8_t slot = 0; slot < VIRTUAL_SLOT_COUNT; ++slot) {
+        if ((undeliveredSlots & (uint8_t)(1U << slot)) == 0) continue;
+        sendFrameToVirtualSlot(slot, CMD_RX_PACKET, payload, len);
+        recentMatch->deliveredSlots |= (uint8_t)(1U << slot);
+        recentMatch->deliveredGenerations[slot] = TCPServer::getSlotGeneration(slot);
+    }
+    // Returning true even when every matching slot already received this
+    // packet prevents handleLoRaRx() from falling back to a TCP broadcast.
+    return true;
+}
+
+static int8_t nextReadyVirtualSlot(uint8_t start) {
+    for (uint8_t n = 0; n < VIRTUAL_SLOT_COUNT; ++n) {
+        uint8_t slot = (uint8_t)((start + n) % VIRTUAL_SLOT_COUNT);
+        if (virtualSlotEligible(slot)) return (int8_t)slot;
+    }
+    return -1;
+}
+
+static void rememberTransmittedPacket(const uint8_t* payload, uint16_t len) {
+    if (!payload || len == 0 || len > MAX_LORA_PAYLOAD) return;
+    lastTransmittedPacket.valid = true;
+    lastTransmittedPacket.len = len;
+    lastTransmittedPacket.completedMs = millis();
+    memcpy(lastTransmittedPacket.data, payload, len);
+}
+
+static bool isRecentTransmittedPacket(const uint8_t* payload, uint16_t len) {
+    if (!lastTransmittedPacket.valid || !payload ||
+        len != lastTransmittedPacket.len || activityHoldMs == 0 ||
+        txEchoHoldMultiplier == 0 ||
+        memcmp(lastTransmittedPacket.data, payload, len) != 0) {
+        return false;
+    }
+
+    uint64_t window = (uint64_t)activityHoldMs * txEchoHoldMultiplier;
+    if (window > UINT32_MAX) window = UINT32_MAX;
+    return (uint32_t)(millis() - lastTransmittedPacket.completedMs) <
+           (uint32_t)window;
+}
+
+static void discardStaleVirtualTx() {
+    for (uint8_t slot = 0; slot < VIRTUAL_SLOT_COUNT; ++slot) {
+        const bool activeOwner =
+            (slot == txOwnerSlot && virtualRadioOperation == VirtualRadioOperation::TX) ||
+            (slot == cadOwnerSlot && virtualRadioOperation == VirtualRadioOperation::CAD_FOR_TX);
+        if (virtualTx[slot].pending && !activeOwner &&
+            !virtualSessionCurrent(slot, virtualTxGeneration[slot])) {
+            virtualTx[slot].pending = false;
+        }
+    }
+}
+
+static void resumeVirtualRx() {
+    virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+    cadOwnerSlot = INVALID_VIRTUAL_SLOT;
+    cadOwnerGeneration = 0;
+    activeVirtualSlot = INVALID_VIRTUAL_SLOT;
+    activeVirtualGeneration = 0;
+    int8_t next = nextReadyVirtualSlot(nextVirtualSlot);
+    if (next >= 0) {
+        nextVirtualSlot = (uint8_t)((next + 1) % VIRTUAL_SLOT_COUNT);
+        beginVirtualProfile((uint8_t)next);
+    } else {
+        radio.standby();
+    }
+}
+
+static VirtualCadStartResult startVirtualCad(VirtualRadioOperation operation,
+                                             uint8_t owner) {
+    if (radioStandby || !virtualSlotEligible(owner)) return VirtualCadStartResult::FAILED;
+    if (virtualRadioOperation != VirtualRadioOperation::RX_SLOT) {
+        return VirtualCadStartResult::BUSY;
+    }
+    radio.standby();
+    delay(1);
+    ChannelScanConfig_t cfg = {};
+    cfg.cad.symNum = cadSymNum;
+    cfg.cad.detPeak = cadDetPeak;
+    cfg.cad.detMin = cadDetMin;
+    cfg.cad.exitMode = cadExitMode;
+    cfg.cad.irqFlags = RADIOLIB_IRQ_CAD_DEFAULT_FLAGS;
+    cfg.cad.irqMask = RADIOLIB_IRQ_CAD_DEFAULT_MASK;
+    dio1Flag = false;
+    const int state = cadCustom
+        ? radio.startChannelScan(cfg)
+        : radio.startChannelScan();
+    if (state != RADIOLIB_ERR_NONE) {
+        startReceive();
+        return VirtualCadStartResult::FAILED;
+    }
+    virtualRadioOperation = operation;
+    cadOwnerSlot = owner;
+    cadOwnerGeneration = TCPServer::getSlotGeneration(owner);
+    cadStartedMs = millis();
+    cadResponsePending = operation == VirtualRadioOperation::CAD_FOR_HOST;
+    return VirtualCadStartResult::STARTED;
+}
+
+static bool enqueueVirtualTx(uint8_t slot, const uint8_t* payload, uint16_t len) {
+    if (slot >= VIRTUAL_SLOT_COUNT || virtualStandby[slot] ||
+        len == 0 || len > MAX_LORA_PAYLOAD) return false;
+    PendingVirtualTx& tx = virtualTx[slot];
+    const bool activeOwner =
+        (virtualRadioOperation == VirtualRadioOperation::TX &&
+         txOwnerSlot == slot) ||
+        (virtualRadioOperation == VirtualRadioOperation::CAD_FOR_TX &&
+         cadOwnerSlot == slot);
+    if (activeOwner) return false;
+    if (tx.pending &&
+        virtualTxGeneration[slot] != TCPServer::getSlotGeneration(slot)) {
+        tx.pending = false;
+    }
+    if (tx.pending) return false;
+    tx.len = len;
+    memcpy(tx.data, payload, len);
+    virtualTxGeneration[slot] = TCPServer::getSlotGeneration(slot);
+    tx.pending = true;
+    return true;
+}
+
+static int8_t nextPendingVirtualTx() {
+    for (uint8_t n = 0; n < VIRTUAL_SLOT_COUNT; ++n) {
+        uint8_t slot = (uint8_t)((nextTxSlot + n) % VIRTUAL_SLOT_COUNT);
+        if (!virtualTx[slot].pending) continue;
+        if (virtualStandby[slot]) continue;
+        if (virtualSessionCurrent(slot, virtualTxGeneration[slot])) {
+            return (int8_t)slot;
+        }
+        virtualTx[slot].pending = false;
+    }
+    return -1;
+}
+
+static bool virtualActivityHoldActive() {
+    return activeVirtualSlot < VIRTUAL_SLOT_COUNT &&
+           virtualSessionCurrent(activeVirtualSlot, activeVirtualGeneration) &&
+           activityHoldUntilMs != 0 &&
+           (int32_t)(millis() - activityHoldUntilMs) < 0;
+}
+
+static void serviceVirtualRadio() {
+    if (!radioReady) return;
+    discardStaleVirtualTx();
+    if (activeVirtualSlot < VIRTUAL_SLOT_COUNT &&
+        !virtualSessionCurrent(activeVirtualSlot, activeVirtualGeneration)) {
+        activeVirtualSlot = INVALID_VIRTUAL_SLOT;
+        activeVirtualGeneration = 0;
+    }
+    if (radioStandby) {
+        if (virtualRadioOperation == VirtualRadioOperation::TX) {
+            radio.standby();
+            radio.finishTransmit();
+            setTxLed(false);
+            isTxActive = false;
+        } else if (virtualRadioOperation != VirtualRadioOperation::RX_SLOT) {
+            radio.standby();
+        }
+        virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+        txOwnerSlot = INVALID_VIRTUAL_SLOT;
+        txOwnerGeneration = 0;
+        cadOwnerSlot = INVALID_VIRTUAL_SLOT;
+        cadOwnerGeneration = 0;
+        cadResponsePending = false;
+        activeVirtualSlot = INVALID_VIRTUAL_SLOT;
+        activeVirtualGeneration = 0;
+        dio1Flag = false;
+        return;
+    }
+
+    // TX owns radio immediately, but sockets remain serviced later in loop().
+    if (virtualRadioOperation == VirtualRadioOperation::TX) {
+        if (dio1Flag) {
+            dio1Flag = false;
+            bool ok = true;
+            radio.finishTransmit();
+            setTxLed(false);
+            isTxActive = false;
+            if (ok) {
+                uint32_t airtime = radio.getTimeOnAir(virtualTx[txOwnerSlot].len);
+                uint8_t resp[4] = {
+                    (uint8_t)(airtime & 0xFF), (uint8_t)((airtime >> 8) & 0xFF),
+                    (uint8_t)((airtime >> 16) & 0xFF), (uint8_t)((airtime >> 24) & 0xFF)
+                };
+                sendFrameToVirtualSlotGeneration(txOwnerSlot, txOwnerGeneration,
+                                                  CMD_TX_DONE, resp, sizeof(resp));
+                rememberTransmittedPacket(virtualTx[txOwnerSlot].data,
+                                          virtualTx[txOwnerSlot].len);
+                status.tx_count++;
+            }
+            virtualTx[txOwnerSlot].pending = false;
+            nextTxSlot = (uint8_t)((txOwnerSlot + 1) % VIRTUAL_SLOT_COUNT);
+            txOwnerSlot = INVALID_VIRTUAL_SLOT;
+            txOwnerGeneration = 0;
+            virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+            activeVirtualSlot = INVALID_VIRTUAL_SLOT;
+            activeVirtualGeneration = 0;
+            int8_t next = nextReadyVirtualSlot(nextVirtualSlot);
+            if (next >= 0) {
+                nextVirtualSlot = (uint8_t)((next + 1) % VIRTUAL_SLOT_COUNT);
+                beginVirtualProfile((uint8_t)next);
+            } else {
+                startReceive();
+            }
+        } else if ((uint32_t)(millis() - txStartedMs) > 4500) {
+            radio.standby();
+            radio.finishTransmit();
+            setTxLed(false);
+            isTxActive = false;
+            uint8_t error = ERR_TX_TIMEOUT;
+            sendFrameToVirtualSlotGeneration(txOwnerSlot, txOwnerGeneration,
+                                              CMD_ERROR, &error, 1);
+            virtualTx[txOwnerSlot].pending = false;
+            nextTxSlot = (uint8_t)((txOwnerSlot + 1) % VIRTUAL_SLOT_COUNT);
+            txOwnerSlot = INVALID_VIRTUAL_SLOT;
+            txOwnerGeneration = 0;
+            virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+            activeVirtualSlot = INVALID_VIRTUAL_SLOT;
+            activeVirtualGeneration = 0;
+        }
+        return;
+    }
+
+    if (virtualRadioOperation == VirtualRadioOperation::CAD_FOR_HOST ||
+        virtualRadioOperation == VirtualRadioOperation::CAD_FOR_TX ||
+        virtualRadioOperation == VirtualRadioOperation::CAD_FOR_SLOT) {
+        if (!dio1Flag && (uint32_t)(millis() - cadStartedMs) < 500) return;
+        uint16_t irq = radio.getIrqFlags();
+        radio.clearIrqFlags(RADIOLIB_IRQ_CAD_DEFAULT_FLAGS);
+        bool timedOut = !dio1Flag;
+        dio1Flag = false;
+        bool busy = !timedOut && ((irq & RADIOLIB_SX126X_IRQ_CAD_DETECTED) != 0);
+        VirtualRadioOperation operation = virtualRadioOperation;
+        uint8_t owner = cadOwnerSlot;
+        uint32_t ownerGeneration = cadOwnerGeneration;
+        virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+        cadOwnerSlot = INVALID_VIRTUAL_SLOT;
+        cadOwnerGeneration = 0;
+        if (operation == VirtualRadioOperation::CAD_FOR_HOST) {
+            if (timedOut) {
+                uint8_t error = ERR_CAD_FAILED;
+                sendFrameToVirtualSlotGeneration(owner, ownerGeneration,
+                                                  CMD_ERROR, &error, 1);
+            } else {
+                uint8_t result = busy ? 1 : 0;
+                sendFrameToVirtualSlotGeneration(owner, ownerGeneration,
+                                                  CMD_CAD_RESP, &result, 1);
+            }
+            if (activeVirtualSlot < VIRTUAL_SLOT_COUNT) startReceive();
+            return;
+        }
+        if (operation == VirtualRadioOperation::CAD_FOR_TX) {
+            if (!virtualSessionCurrent(owner, ownerGeneration)) {
+                virtualTx[owner].pending = false;
+                nextTxSlot = (uint8_t)((owner + 1) % VIRTUAL_SLOT_COUNT);
+                resumeVirtualRx();
+                return;
+            }
+            if (timedOut || busy) {
+                uint8_t error = timedOut ? ERR_CAD_FAILED : ERR_CHANNEL_BUSY;
+                sendFrameToVirtualSlotGeneration(owner, ownerGeneration,
+                                                  CMD_ERROR, &error, 1);
+                virtualTx[owner].pending = false;
+                nextTxSlot = (uint8_t)((owner + 1) % VIRTUAL_SLOT_COUNT);
+                resumeVirtualRx();
+                return;
+            }
+            radio.standby();
+            RFFrontEnd::prepareTransmit();
+            dio1Flag = false;
+            txOwnerSlot = owner;
+            txOwnerGeneration = virtualTxGeneration[owner];
+            txStartedMs = millis();
+            isTxActive = true;
+            setTxLed(true);
+            int state = radio.startTransmit(virtualTx[owner].data, virtualTx[owner].len);
+            if (state != RADIOLIB_ERR_NONE) {
+                isTxActive = false;
+                setTxLed(false);
+                uint8_t error = ERR_TX_TIMEOUT;
+                sendFrameToVirtualSlotGeneration(owner, virtualTxGeneration[owner],
+                                                  CMD_ERROR, &error, 1);
+                virtualTx[owner].pending = false;
+                virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+                txOwnerSlot = INVALID_VIRTUAL_SLOT;
+                txOwnerGeneration = 0;
+                resumeVirtualRx();
+            } else {
+                virtualRadioOperation = VirtualRadioOperation::TX;
+            }
+            return;
+        }
+        // Slot CAD is advisory: keep RX on detected activity for bounded hold.
+        if (busy) activityHoldUntilMs = millis() + activityHoldMs;
+        if (operation == VirtualRadioOperation::CAD_FOR_SLOT) {
+            rxSlotStartedMs = millis();
+            if (!busy) {
+                int8_t next = nextReadyVirtualSlot(nextVirtualSlot);
+                if (next >= 0) {
+                    nextVirtualSlot = (uint8_t)((next + 1) % VIRTUAL_SLOT_COUNT);
+                    beginVirtualProfile((uint8_t)next);
+                }
+            }
+        }
+        if (activeVirtualSlot < VIRTUAL_SLOT_COUNT) startReceive();
+        return;
+    }
+
+    // A queued forward must not preempt the receive profile while CAD or a
+    // completed RX packet is holding detected activity. Keep servicing the
+    // sockets and leave the request queued until the hold deadline expires.
+    if (virtualActivityHoldActive()) return;
+
+    int8_t pending = nextPendingVirtualTx();
+    if (pending >= 0) {
+        uint8_t owner = (uint8_t)pending;
+        nextTxSlot = (uint8_t)((owner + 1) % VIRTUAL_SLOT_COUNT);
+        if (!beginVirtualProfile(owner)) {
+            uint8_t error = ERR_INVALID_CONFIG;
+            sendFrameToVirtualSlot(owner, CMD_ERROR, &error, 1);
+            virtualTx[owner].pending = false;
+        } else if (autoCadEnabled) {
+            VirtualCadStartResult result =
+                startVirtualCad(VirtualRadioOperation::CAD_FOR_TX, owner);
+            if (result == VirtualCadStartResult::FAILED) {
+                uint8_t error = ERR_CAD_FAILED;
+                sendFrameToVirtualSlotGeneration(owner, virtualTxGeneration[owner],
+                                                  CMD_ERROR, &error, 1);
+                virtualTx[owner].pending = false;
+                resumeVirtualRx();
+            }
+        } else {
+            radio.standby();
+            RFFrontEnd::prepareTransmit();
+            dio1Flag = false;
+            txOwnerSlot = owner;
+            txOwnerGeneration = virtualTxGeneration[owner];
+            txStartedMs = millis();
+            isTxActive = true;
+            setTxLed(true);
+            int state = radio.startTransmit(virtualTx[owner].data, virtualTx[owner].len);
+            virtualRadioOperation = state == RADIOLIB_ERR_NONE
+                ? VirtualRadioOperation::TX : VirtualRadioOperation::RX_SLOT;
+            if (state != RADIOLIB_ERR_NONE) {
+                isTxActive = false;
+                setTxLed(false);
+                uint8_t error = ERR_TX_TIMEOUT;
+                sendFrameToVirtualSlotGeneration(owner, virtualTxGeneration[owner],
+                                                  CMD_ERROR, &error, 1);
+                virtualTx[owner].pending = false;
+                txOwnerSlot = INVALID_VIRTUAL_SLOT;
+                txOwnerGeneration = 0;
+                resumeVirtualRx();
+            }
+        }
+        return;
+    }
+
+    if (!virtualTcpReady()) return;
+    if (activeVirtualSlot >= VIRTUAL_SLOT_COUNT) {
+        int8_t next = nextReadyVirtualSlot(nextVirtualSlot);
+        if (next >= 0) {
+            nextVirtualSlot = (uint8_t)((next + 1) % VIRTUAL_SLOT_COUNT);
+            beginVirtualProfile((uint8_t)next);
+        }
+        return;
+    }
+    if ((uint32_t)(millis() - rxSlotStartedMs) < rxSlotDurationMs) return;
+
+    int8_t next = nextReadyVirtualSlot(nextVirtualSlot);
+    if (next < 0) return;
+    nextVirtualSlot = (uint8_t)((next + 1) % VIRTUAL_SLOT_COUNT);
+    // CAD is skipped for very short slots; profile switch remains bounded and
+    // measured by rxSlotStartedMs, so 5 ms is a lower scheduling request, not
+    // a promise that every radio operation fits inside 5 ms.
+    if (rxSlotDurationMs >= 20) {
+        if (startVirtualCad(VirtualRadioOperation::CAD_FOR_SLOT,
+                            activeVirtualSlot) == VirtualCadStartResult::STARTED) {
+            return;
+        }
+    }
+    beginVirtualProfile((uint8_t)next);
+}
+
 // ─── Handle received LoRa packet ────────────────────────────
 void handleLoRaRx() {
     int len = radio.getPacketLength();
@@ -808,6 +1545,15 @@ void handleLoRaRx() {
         return;
     }
 
+    // Suppress an exact RF reflection of the most recently completed TX before
+    // it reaches counters, activity hold, or virtual-slot fan-out.
+    if (isRecentTransmittedPacket(rxBuf, (uint16_t)len)) {
+        suppressedRxCount++;
+        lastPacketTime = millis();
+        startReceive();
+        return;
+    }
+
     int16_t rssi = (int16_t)radio.getRSSI();
     int16_t snr  = (int16_t)(radio.getSNR() * 10.0f);
     int16_t signal_rssi = rssi;
@@ -815,6 +1561,13 @@ void handleLoRaRx() {
     status.rx_count++;
     status.last_rssi = rssi;
     status.last_snr  = snr;
+
+    // Receiving a packet is definitive channel activity. Preserve this RX
+    // profile for the configured hold interval and defer queued virtual TX
+    // requests rather than letting a forwarding client immediately take over.
+    if (activeVirtualSlot < VIRTUAL_SLOT_COUNT && activityHoldMs > 0) {
+        activityHoldUntilMs = millis() + activityHoldMs;
+    }
 
     // TFT cache — display the freshest received-packet quality
     // alongside the rest of the radio state on the next status
@@ -833,7 +1586,17 @@ void handleLoRaRx() {
     rxPayload[5] = (signal_rssi >> 8) & 0xFF;
     memcpy(rxPayload + 6, rxBuf, len);
 
-    broadcastFrame(CMD_RX_PACKET, rxPayload, 6 + len);
+    if (sendRxPacketToMatchingVirtualSlots(rxPayload, 6 + len)) {
+        // TCP virtual-radio routing must not suppress the legacy USB/UART
+        // event stream used by local controllers and diagnostics.
+        writeFrame(CMD_RX_PACKET, rxPayload, 6 + len,
+                   /*toSerial=*/true, /*toTCP=*/false, /*toUart=*/uartEnabled);
+    } else if (virtualTcpReady()) {
+        writeFrame(CMD_RX_PACKET, rxPayload, 6 + len,
+                   /*toSerial=*/true, /*toTCP=*/false, /*toUart=*/uartEnabled);
+    } else {
+        broadcastFrame(CMD_RX_PACKET, rxPayload, 6 + len);
+    }
     lastPacketTime = millis();
     startReceive();
 }
@@ -843,6 +1606,21 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
                         TransportSource src) {
     // Any successfully-processed host frame counts toward OTA sanity.
     OTAManager::notifyValidFrame();
+
+    const uint8_t requestSlot = tcpCommandSlot();
+    const bool virtualTcpCommand = src == TransportSource::TCP &&
+                                   requestSlot < VIRTUAL_SLOT_COUNT;
+    if (virtualTcpCommand) initializeVirtualConfigs();
+
+    // Once a TCP virtual-radio session is ready, it owns the SX1262. USB/UART
+    // must not reconfigure, scan, or transmit through the physical radio
+    // behind the scheduler's back. Global standby/resume remains allowed so
+    // an operator can deliberately stop and restart the multiplexed radio.
+    if (src != TransportSource::TCP && virtualTcpReady() &&
+        virtualRadioOwnershipCommand(cmd)) {
+        sendError(ERR_RADIO_BUSY, src);
+        return;
+    }
 
     // Boards without a LoRa radio, or boards where SX1262 init failed,
     // ack the non-radio commands (PING, GET_VERSION, GET_WIFI, AUTH, …)
@@ -865,6 +1643,13 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
     case CMD_TX_REQUEST: {
         if (len == 0 || len > MAX_LORA_PAYLOAD) {
             sendError(ERR_PAYLOAD_TOO_BIG, src);
+            break;
+        }
+        if (virtualTcpCommand) {
+            if (!enqueueVirtualTx(requestSlot, payload, len)) {
+                uint8_t error = ERR_RADIO_BUSY;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+            }
             break;
         }
         // v0.5.7: non-blocking TX with our own timeout.
@@ -965,6 +1750,7 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
         lastPacketTime = millis();
 
         if (txOk) {
+            rememberTransmittedPacket(payload, len);
             status.tx_count++;
             uint32_t airtime_us = radio.getTimeOnAir(len);
             uint8_t resp[4];
@@ -990,6 +1776,21 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
     }
 
     case CMD_CAD_REQUEST: {
+        if (virtualTcpCommand) {
+            if (activeVirtualSlot != requestSlot && !beginVirtualProfile(requestSlot)) {
+                uint8_t error = ERR_INVALID_CONFIG;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+                break;
+            }
+            VirtualCadStartResult cadResult =
+                startVirtualCad(VirtualRadioOperation::CAD_FOR_HOST, requestSlot);
+            if (cadResult != VirtualCadStartResult::STARTED) {
+                uint8_t error = cadResult == VirtualCadStartResult::BUSY
+                    ? ERR_RADIO_BUSY : ERR_CAD_FAILED;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+            }
+            break;
+        }
         // v0.5.8: non-blocking CAD with our own timeout.
         // The previous radio.scanChannel() was synchronous and would block
         // until CAD_DONE IRQ arrived. When SX1262 dropped that IRQ (first
@@ -1067,6 +1868,28 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
             sendError(ERR_INVALID_CONFIG, src);
             break;
         }
+        if (virtualTcpCommand) {
+            if (activeVirtualSlot == requestSlot &&
+                virtualRadioOperation != VirtualRadioOperation::RX_SLOT) {
+                uint8_t error = ERR_RADIO_BUSY;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+                break;
+            }
+            virtualCadSymNum[requestSlot] = payload[0];
+            virtualCadDetPeak[requestSlot] = payload[1];
+            virtualCadDetMin[requestSlot] = payload[2];
+            virtualCadExitMode[requestSlot] = payload[3];
+            virtualCadCustom[requestSlot] = true;
+            if (activeVirtualSlot == requestSlot) {
+                cadSymNum = payload[0];
+                cadDetPeak = payload[1];
+                cadDetMin = payload[2];
+                cadExitMode = payload[3];
+                cadCustom = true;
+            }
+            sendFrame(CMD_CAD_PARAMS_RESP, payload, 4, src);
+            break;
+        }
         cadSymNum   = payload[0];
         cadDetPeak  = payload[1];
         cadDetMin   = payload[2];
@@ -1085,7 +1908,20 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
     }
 
     case CMD_RX_START: {
-        startReceive();
+        if (virtualTcpCommand) {
+            if (virtualRadioOperation != VirtualRadioOperation::RX_SLOT) {
+                uint8_t error = ERR_RADIO_BUSY;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+                break;
+            }
+            if (!beginVirtualProfile(requestSlot)) {
+                uint8_t error = ERR_INVALID_CONFIG;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+                break;
+            }
+        } else {
+            startReceive();
+        }
         sendFrame(CMD_RX_STARTED, nullptr, 0, src);
         break;
     }
@@ -1093,6 +1929,23 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
     case CMD_SET_CONFIG: {
         if (len != sizeof(RadioConfig)) {
             sendError(ERR_INVALID_CONFIG, src);
+            break;
+        }
+        if (virtualTcpCommand) {
+            if (activeVirtualSlot == requestSlot &&
+                virtualRadioOperation != VirtualRadioOperation::RX_SLOT) {
+                uint8_t error = ERR_RADIO_BUSY;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+                break;
+            }
+            memcpy(&virtualConfigs[requestSlot], payload, sizeof(RadioConfig));
+            if (activeVirtualSlot == requestSlot && !applyConfig(virtualConfigs[requestSlot])) {
+                sendError(ERR_INVALID_CONFIG, src);
+                break;
+            }
+            sendFrame(CMD_CONFIG_RESP, (uint8_t*)&virtualConfigs[requestSlot],
+                      sizeof(RadioConfig), src);
+            if (activeVirtualSlot == requestSlot) startReceive();
             break;
         }
         memcpy(&currentConfig, payload, sizeof(RadioConfig));
@@ -1114,7 +1967,12 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
     }
 
     case CMD_GET_CONFIG: {
-        sendFrame(CMD_CONFIG_RESP, (uint8_t*)&currentConfig, sizeof(RadioConfig), src);
+        if (virtualTcpCommand) {
+            sendFrame(CMD_CONFIG_RESP, (uint8_t*)&virtualConfigs[requestSlot],
+                      sizeof(RadioConfig), src);
+        } else {
+            sendFrame(CMD_CONFIG_RESP, (uint8_t*)&currentConfig, sizeof(RadioConfig), src);
+        }
         break;
     }
 
@@ -1236,6 +2094,23 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
         break;
     }
     case CMD_RADIO_STANDBY: {
+        if (virtualTcpCommand) {
+            if (activeVirtualSlot == requestSlot &&
+                virtualRadioOperation != VirtualRadioOperation::RX_SLOT) {
+                uint8_t error = ERR_RADIO_BUSY;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+                break;
+            }
+            virtualStandby[requestSlot] = true;
+            if (activeVirtualSlot == requestSlot) {
+                radio.standby();
+                activeVirtualSlot = INVALID_VIRTUAL_SLOT;
+                activeVirtualGeneration = 0;
+            }
+            uint8_t statusCode = 0;
+            sendFrame(CMD_RADIO_STANDBY_RESP, &statusCode, 1, src);
+            break;
+        }
         radio.standby();
         radioStandby = true;
         oled.setStandby(true);
@@ -1248,12 +2123,35 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
         break;
     }
     case CMD_RADIO_RESUME: {
+        if (virtualTcpCommand) {
+            virtualStandby[requestSlot] = false;
+            bool ok = virtualRadioOperation == VirtualRadioOperation::RX_SLOT &&
+                      beginVirtualProfile(requestSlot);
+            uint8_t statusCode = ok ? 0 : 1;
+            if (!ok && virtualRadioOperation != VirtualRadioOperation::RX_SLOT) {
+                uint8_t error = ERR_RADIO_BUSY;
+                sendFrameToVirtualSlot(requestSlot, CMD_ERROR, &error, 1);
+            }
+            sendFrame(CMD_RADIO_RESUME_RESP, &statusCode, 1, src);
+            break;
+        }
         radioStandby = false;
         oled.setStandby(false);
 #if defined(BOARD_HELTEC_T114)
         NodeState::setStandby(false);
 #endif
-        bool ok = applyConfig(currentConfig) && startReceive();
+        bool ok;
+        if (virtualTcpReady()) {
+            virtualRadioOperation = VirtualRadioOperation::RX_SLOT;
+            activeVirtualSlot = INVALID_VIRTUAL_SLOT;
+            activeVirtualGeneration = 0;
+            int8_t next = nextReadyVirtualSlot(nextVirtualSlot);
+            ok = next >= 0 && beginVirtualProfile((uint8_t)next);
+            if (ok) nextVirtualSlot = (uint8_t)((next + 1) % VIRTUAL_SLOT_COUNT);
+            else radio.standby();
+        } else {
+            ok = applyConfig(currentConfig) && startReceive();
+        }
         LOG_R_INFO("radio RESUME (ok=%d)", (int)ok);
         uint8_t status = ok ? 0 : 1;
         sendFrame(CMD_RADIO_RESUME_RESP, &status, 1, src);
@@ -1540,6 +2438,10 @@ void setup() {
     // Ethernet (`ethernet.enabled = false`) skip straight to Wi-Fi.
     WifiManager::loadConfigOnly();
     const auto& netCfg = WifiManager::getConfig();
+    rxSlotDurationMs = netCfg.rxSlotMs < MIN_RX_SLOT_MS
+        ? MIN_RX_SLOT_MS : netCfg.rxSlotMs;
+    activityHoldMs = netCfg.activityHoldMs;
+    txEchoHoldMultiplier = netCfg.txEchoHoldMultiplier;
     bool useEthernet = false;
     if (BOARD.ethernet.enabled) {
         EthernetManager::begin(WifiManager::getHostname(),
@@ -1585,8 +2487,7 @@ void setup() {
         String token = BOARD.has_wifi ? wcfg.tcpToken : String();
 #endif
         uint16_t port = wcfg.tcpPort ? wcfg.tcpPort : 5055;
-        TCPServer::begin(port, token);
-        tcpStarted = true;
+        tcpStarted = TCPServer::begin(port, token);
 
         OTAManager::begin(deviceHostname, token);
         otaStarted = true;
@@ -1710,6 +2611,10 @@ void loop() {
 
     compatWdtReset();   // feed the loop watchdog every pass
 
+    // TCP profile switching and TX arbitration run cooperatively here. The
+    // transport remains serviced every loop; no RF operation owns a socket.
+    serviceVirtualRadio();
+
     // DIO1 during TX is consumed by the TX handler's own wait loop; in
     // loop() we only act on it when the radio is in RX mode.
     if (dio1Flag && !isTxActive) {
@@ -1752,8 +2657,7 @@ void loop() {
         String token = BOARD.has_wifi ? wcfg.tcpToken : String();
 #endif
         uint16_t port = wcfg.tcpPort ? wcfg.tcpPort : 5055;
-        TCPServer::begin(port, token);
-        tcpStarted = true;
+        tcpStarted = TCPServer::begin(port, token);
     }
     if (!otaStarted && netUp) {
         const auto& wcfg = WifiManager::getConfig();

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -20,6 +20,7 @@
 #include <WebServer.h>
 #include <ETH.h>
 #include <WiFi.h>
+#include <cstdlib>
 #include <esp_ota_ops.h>
 
 namespace OTAManager {
@@ -283,35 +284,79 @@ static String buildSystemJson(const RuntimeStats::Snapshot& snap,
     return body;
 }
 
-static String buildRadioJson(const RuntimeStats::Snapshot& snap) {
+static void appendRadioConfigJson(String& body, const RadioConfig& radio) {
+    body += F("\"frequency_hz\":");
+    body += String(radio.freq_hz);
+    body += F(",\"frequency_mhz\":");
+    body += String(radio.freq_hz / 1000000.0f, 3);
+    body += F(",\"bandwidth_hz\":");
+    body += String(radio.bandwidth_hz);
+    body += F(",\"bandwidth_khz\":");
+    body += String(radio.bandwidth_hz / 1000.0f, 1);
+    body += F(",\"spreading_factor\":");
+    body += String(radio.sf);
+    body += F(",\"coding_rate\":");
+    body += String(radio.cr);
+    body += F(",\"tx_power_dbm\":");
+    body += String(radio.power_dbm);
+    body += F(",\"syncword\":");
+    body += jsonQuote(String("0x") + String(radio.syncword, HEX));
+    body += F(",\"syncword_value\":");
+    body += String(radio.syncword);
+    body += F(",\"preamble_len\":");
+    body += String(radio.preamble_len);
+}
+
+static String buildVirtualSlotJson(const RuntimeStats::VirtualSlotSnapshot& slot) {
     String body;
     body.reserve(512);
+    body += F("{\"slot\":");
+    body += String(slot.slot);
+    body += F(",\"port\":");
+    body += String(slot.port);
+    body += F(",\"active\":");
+    body += boolJson(slot.active);
+    body += F(",\"on_air\":");
+    body += boolJson(slot.onAir);
+    body += F(",\"standby\":");
+    body += boolJson(slot.standby);
+    body += F(",\"client_ip\":");
+    body += slot.clientIP.length() > 0 ? jsonQuote(slot.clientIP) : String("null");
+    body += F(",\"recieve_mirroing\":[");
+    for (uint8_t i = 0; i < slot.receiveMirroringCount; ++i) {
+        if (i > 0) body += F(",");
+        body += String(slot.receiveMirroring[i]);
+    }
+    body += F("]");
+    body += F(",\"auto_cad_enabled\":");
+    body += boolJson(slot.autoCadEnabled);
+    body += F(",\"cad_custom\":");
+    body += boolJson(slot.cadCustom);
+    body += F(",\"cad_sym_num\":");
+    body += String(slot.cadSymNum);
+    body += F(",\"cad_det_peak\":");
+    body += String(slot.cadDetPeak);
+    body += F(",\"cad_det_min\":");
+    body += String(slot.cadDetMin);
+    body += F(",\"cad_exit_mode\":");
+    body += String(slot.cadExitMode);
+    body += F(",");
+    appendRadioConfigJson(body, slot.radio);
+    body += F("}");
+    return body;
+}
+
+static String buildRadioJson(const RuntimeStats::Snapshot& snap) {
+    String body;
+    body.reserve(1024);
     body += F("{\"state\":");
     body += jsonQuote(radioStateLabel(snap));
     body += F(",\"standby\":");
     body += boolJson(snap.radioStandby);
     body += F(",\"auto_cad_enabled\":");
     body += boolJson(snap.autoCadEnabled);
-    body += F(",\"frequency_hz\":");
-    body += String(snap.radio.freq_hz);
-    body += F(",\"frequency_mhz\":");
-    body += String(snap.radio.freq_hz / 1000000.0f, 3);
-    body += F(",\"bandwidth_hz\":");
-    body += String(snap.radio.bandwidth_hz);
-    body += F(",\"bandwidth_khz\":");
-    body += String(snap.radio.bandwidth_hz / 1000.0f, 1);
-    body += F(",\"spreading_factor\":");
-    body += String(snap.radio.sf);
-    body += F(",\"coding_rate\":");
-    body += String(snap.radio.cr);
-    body += F(",\"tx_power_dbm\":");
-    body += String(snap.radio.power_dbm);
-    body += F(",\"syncword\":");
-    body += jsonQuote(String("0x") + String(snap.radio.syncword, HEX));
-    body += F(",\"syncword_value\":");
-    body += String(snap.radio.syncword);
-    body += F(",\"preamble_len\":");
-    body += String(snap.radio.preamble_len);
+    body += F(",");
+    appendRadioConfigJson(body, snap.radio);
     if (RFFrontEnd::hasHeltecV43LnaControl()) {
         body += F(",\"heltec_v43_external_lna_enabled\":");
         body += boolJson(RFFrontEnd::isExternalLnaEnabled());
@@ -320,6 +365,25 @@ static String buildRadioJson(const RuntimeStats::Snapshot& snap) {
         body += F(",\"agc_reset_interval_sec\":");
         body += String(RFFrontEnd::getAgcResetIntervalSec());
     }
+    body += F(",\"multiplexed\":");
+    body += boolJson(snap.virtualSlotCount > 0);
+    body += F(",\"active_slot\":");
+    bool hasOnAirSlot = false;
+    uint8_t onAirSlot = 0;
+    for (uint8_t i = 0; i < snap.virtualSlotCount; ++i) {
+        if (snap.virtualSlots[i].onAir) {
+            hasOnAirSlot = true;
+            onAirSlot = snap.virtualSlots[i].slot;
+            break;
+        }
+    }
+    body += hasOnAirSlot ? String(onAirSlot) : String("null");
+    body += F(",\"slots\":[");
+    for (uint8_t i = 0; i < snap.virtualSlotCount; ++i) {
+        if (i > 0) body += F(",");
+        body += buildVirtualSlotJson(snap.virtualSlots[i]);
+    }
+    body += F("]");
     body += F("}");
     return body;
 }
@@ -331,6 +395,8 @@ static String buildCountersJson(const RuntimeStats::Snapshot& snap) {
     body += String(snap.status.rx_count);
     body += F(",\"tx_packets\":");
     body += String(snap.status.tx_count);
+    body += F(",\"suppressed_rx\":");
+    body += String(snap.suppressedRxCount);
     body += F(",\"crc_errors\":");
     body += String(snap.status.crc_errors);
     body += F(",\"last_rssi_dbm\":");
@@ -399,6 +465,12 @@ static String buildConfigJson(const WifiManager::Config& cfg) {
     body += jsonQuote(cfg.tcpToken);
     body += F(",\"tcp_port\":");
     body += String(cfg.tcpPort);
+    body += F(",\"rx_slot_ms\":");
+    body += String(cfg.rxSlotMs);
+    body += F(",\"activity_hold_ms\":");
+    body += String(cfg.activityHoldMs);
+    body += F(",\"tx_echo_hold_multiplier\":");
+    body += String(cfg.txEchoHoldMultiplier);
     body += F(",\"use_static_ip\":");
     body += boolJson(cfg.useStaticIP);
     body += F(",\"static_ip\":");
@@ -461,6 +533,103 @@ static String buildStatsJson(const RuntimeStats::Snapshot& snap,
     return body;
 }
 
+enum class VirtualSlotTableRow : uint8_t {
+    STATUS,
+    TCP_PORT,
+    CLIENT,
+    FREQUENCY,
+    BANDWIDTH,
+    SPREADING_FACTOR,
+    CODING_RATE,
+    TX_POWER,
+    SYNCWORD,
+    PREAMBLE,
+    AUTO_CAD,
+    CAD_CUSTOM,
+    CAD_SYMBOLS,
+    CAD_DET_PEAK,
+    CAD_DET_MIN,
+    CAD_EXIT_MODE,
+    RECEIVE_MIRRORING
+};
+
+static void appendVirtualSlotTableRow(String& body,
+                                      const RuntimeStats::Snapshot& snap,
+                                      const char* label,
+                                      VirtualSlotTableRow row) {
+    body += F("<tr><th scope='row'>");
+    body += htmlEscape(String(label));
+    body += F("</th>");
+    for (uint8_t i = 0; i < snap.virtualSlotCount; ++i) {
+        const RuntimeStats::VirtualSlotSnapshot& slot = snap.virtualSlots[i];
+        String value;
+        switch (row) {
+            case VirtualSlotTableRow::STATUS:
+                value = slot.standby ? "Standby" : (slot.onAir ? "On air" : "Ready");
+                break;
+            case VirtualSlotTableRow::TCP_PORT:
+                value = String(slot.port);
+                break;
+            case VirtualSlotTableRow::CLIENT:
+                value = slot.clientIP.length() > 0 ? slot.clientIP : String("none");
+                break;
+            case VirtualSlotTableRow::FREQUENCY:
+                value = String(slot.radio.freq_hz / 1000000.0f, 3) + " MHz";
+                break;
+            case VirtualSlotTableRow::BANDWIDTH:
+                value = String(slot.radio.bandwidth_hz / 1000.0f, 1) + " kHz";
+                break;
+            case VirtualSlotTableRow::SPREADING_FACTOR:
+                value = String("SF") + String(slot.radio.sf);
+                break;
+            case VirtualSlotTableRow::CODING_RATE:
+                value = String("4/") + String(slot.radio.cr);
+                break;
+            case VirtualSlotTableRow::TX_POWER:
+                value = String(slot.radio.power_dbm) + " dBm";
+                break;
+            case VirtualSlotTableRow::SYNCWORD:
+                value = String("0x") + String(slot.radio.syncword, HEX);
+                break;
+            case VirtualSlotTableRow::PREAMBLE:
+                value = String(slot.radio.preamble_len);
+                break;
+            case VirtualSlotTableRow::AUTO_CAD:
+                value = slot.autoCadEnabled ? "On" : "Off";
+                break;
+            case VirtualSlotTableRow::CAD_CUSTOM:
+                value = slot.cadCustom ? "Custom" : "RadioLib default";
+                break;
+            case VirtualSlotTableRow::CAD_SYMBOLS:
+                value = String(slot.cadSymNum);
+                break;
+            case VirtualSlotTableRow::CAD_DET_PEAK:
+                value = String(slot.cadDetPeak);
+                break;
+            case VirtualSlotTableRow::CAD_DET_MIN:
+                value = String(slot.cadDetMin);
+                break;
+            case VirtualSlotTableRow::CAD_EXIT_MODE:
+                value = String("0x") + String(slot.cadExitMode, HEX);
+                break;
+            case VirtualSlotTableRow::RECEIVE_MIRRORING:
+                if (slot.receiveMirroringCount == 0) {
+                    value = "none";
+                } else {
+                    for (uint8_t i = 0; i < slot.receiveMirroringCount; ++i) {
+                        if (i > 0) value += ", ";
+                        value += String("Slot ") + String(slot.receiveMirroring[i]);
+                    }
+                }
+                break;
+        }
+        body += F("<td>");
+        body += htmlEscape(value);
+        body += F("</td>");
+    }
+    body += F("</tr>");
+}
+
 static bool parseJsonIp(JsonVariantConst value, IPAddress& ip, const char* field, String& error) {
     if (value.isNull()) {
         ip = IPAddress((uint32_t)0);
@@ -478,6 +647,21 @@ static bool parseJsonIp(JsonVariantConst value, IPAddress& ip, const char* field
     }
     if (!ip.fromString(raw)) {
         error = String(field) + " is not a valid IPv4 address.";
+        return false;
+    }
+    return true;
+}
+
+static bool parseJsonUint32(JsonVariantConst value, uint32_t& output,
+                            const String& field, uint32_t minimum,
+                            const String& minimumMessage, String& error) {
+    if (!value.is<uint32_t>()) {
+        error = field + " must be an unsigned integer.";
+        return false;
+    }
+    output = value.as<uint32_t>();
+    if (output < minimum) {
+        error = field + minimumMessage;
         return false;
     }
     return true;
@@ -525,6 +709,28 @@ static bool applyConfigPatch(JsonVariantConst root, WifiManager::Config& cfg, St
             error = "tcp_port must be between 1 and 65535.";
             return false;
         }
+    }
+
+    JsonVariantConst rxSlotVal = obj["rx_slot_ms"];
+    if (!rxSlotVal.isNull() &&
+        !parseJsonUint32(rxSlotVal, cfg.rxSlotMs, "rx_slot_ms",
+                         WifiManager::MIN_RX_SLOT_MS,
+                         " must be at least 5 milliseconds.", error)) {
+        return false;
+    }
+
+    JsonVariantConst activityHoldVal = obj["activity_hold_ms"];
+    if (!activityHoldVal.isNull() &&
+        !parseJsonUint32(activityHoldVal, cfg.activityHoldMs, "activity_hold_ms",
+                         0, "", error)) {
+        return false;
+    }
+
+    JsonVariantConst txEchoHoldMultiplierVal = obj["tx_echo_hold_multiplier"];
+    if (!txEchoHoldMultiplierVal.isNull() &&
+        !parseJsonUint32(txEchoHoldMultiplierVal, cfg.txEchoHoldMultiplier,
+                         "tx_echo_hold_multiplier", 0, "", error)) {
+        return false;
     }
 
     JsonVariantConst staticVal = obj["use_static_ip"];
@@ -826,6 +1032,20 @@ static void handleRoot() {
     }
     body += F("<button type='submit'>Save network settings</button></form></div></details>");
 
+    body += F("<details><summary>TCP Multiplexing</summary><div class='inside'>"
+              "<p>Configure the cooperative receive scheduler used by the four TCP virtual-radio slots."
+              " The base TCP port and the next three ports remain connected while the physical radio rotates between them.</p>"
+              "<form method='POST' action='/multiplexing'>"
+              "<div class='grid'>"
+              "<div><label>RX slot dwell (ms)</label><input type='number' name='rx_slot_ms' min='5' max='4294967295' step='1' required value='");
+    body += String(cfg.rxSlotMs);
+    body += F("'></div><div><label>Activity hold (ms)</label><input type='number' name='activity_hold_ms' min='0' max='4294967295' step='1' required value='");
+    body += String(cfg.activityHoldMs);
+    body += F("'></div><div><label>TX echo hold multiplier</label><input type='number' name='tx_echo_hold_multiplier' min='0' max='4294967295' step='1' required value='");
+    body += String(cfg.txEchoHoldMultiplier);
+    body += F("'></div></div><p class='m'>RX slot dwell must be at least 5 ms. Activity hold keeps a slot active after CAD/RX traffic. An exact copy of the last transmitted packet is ignored for activity hold multiplied by the TX echo value; 0 disables suppression. Reboot required.</p>"
+              "<button type='submit'>Save multiplexing settings</button></form></div></details>");
+
     if (RFFrontEnd::hasHeltecV43LnaControl()) {
         body += F("<details open><summary>Heltec V4.3 RF Front-End</summary><div class='inside'>"
                   "<p>Toggle the KCT8103L external RX LNA for receive only. The firmware always bypasses the FEM LNA during transmit so the TX path remains available.</p>"
@@ -909,6 +1129,9 @@ static void handleStats() {
               ".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75em 1em}"
               ".kv{border:1px solid #ddd;border-radius:8px;background:#fff;padding:.7em .8em}"
               ".k{display:block;color:#666;font-size:.9em;margin-bottom:.2em}.v{font-weight:600}"
+              ".table-wrap{overflow-x:auto;border:1px solid #ddd;border-radius:8px;background:#fff}"
+              ".slots{border-collapse:collapse;min-width:700px;width:100%}.slots th,.slots td{border-bottom:1px solid #e5e5e5;padding:.55em .7em;text-align:left;white-space:nowrap}"
+              ".slots thead th{background:#f1f1f1}.slots tbody th{color:#666;font-weight:600;background:#fafafa}"
               ".actions{margin:1em 0}.actions a{margin-right:1em}code{font-family:ui-monospace,SFMono-Regular,monospace;background:#f3f3f3;padding:.1em .35em;border-radius:4px}"
               "@media (max-width:640px){body{padding:0 .75em}}</style></head><body>");
     body += "<h2>" + modemTitle() + " Stats</h2>";
@@ -948,21 +1171,50 @@ static void handleStats() {
     }
     body += "</div></div>";
 
-    body += F("<h3>Radio</h3><div class='grid'>");
-    body += "<div class='kv'><span class='k'>State</span><span class='v'>" + String(radioStateLabel(snap)) + "</span></div>";
-    body += "<div class='kv'><span class='k'>Frequency</span><span class='v'>" + String(snap.radio.freq_hz / 1000000.0f, 3) + " MHz</span></div>";
-    body += "<div class='kv'><span class='k'>Bandwidth</span><span class='v'>" + String(snap.radio.bandwidth_hz / 1000.0f, 1) + " kHz</span></div>";
-    body += "<div class='kv'><span class='k'>Spreading factor</span><span class='v'>SF" + String(snap.radio.sf) + "</span></div>";
-    body += "<div class='kv'><span class='k'>Coding rate</span><span class='v'>4/" + String(snap.radio.cr) + "</span></div>";
-    body += "<div class='kv'><span class='k'>TX power</span><span class='v'>" + String(snap.radio.power_dbm) + " dBm</span></div>";
-    body += "<div class='kv'><span class='k'>Syncword</span><span class='v'>0x" + String(snap.radio.syncword, HEX) + "</span></div>";
-    body += "<div class='kv'><span class='k'>Preamble</span><span class='v'>" + String(snap.radio.preamble_len) + "</span></div>";
-    body += "<div class='kv'><span class='k'>Auto CAD</span><span class='v'>" + String(snap.autoCadEnabled ? "On" : "Off") + "</span></div>";
-    body += "</div>";
+    if (snap.virtualSlotCount > 0) {
+        body += F("<h3>TCP multiplex slots</h3><div class='table-wrap'><table class='slots'><thead><tr><th>Setting</th>");
+        for (uint8_t i = 0; i < snap.virtualSlotCount; ++i) {
+            const RuntimeStats::VirtualSlotSnapshot& slot = snap.virtualSlots[i];
+            body += "<th>Slot " + String(slot.slot) + "<br><span class='m'>TCP " +
+                    String(slot.port) + "</span></th>";
+        }
+        body += F("</tr></thead><tbody>");
+        appendVirtualSlotTableRow(body, snap, "Status", VirtualSlotTableRow::STATUS);
+        appendVirtualSlotTableRow(body, snap, "TCP port", VirtualSlotTableRow::TCP_PORT);
+        appendVirtualSlotTableRow(body, snap, "Client", VirtualSlotTableRow::CLIENT);
+        appendVirtualSlotTableRow(body, snap, "Frequency", VirtualSlotTableRow::FREQUENCY);
+        appendVirtualSlotTableRow(body, snap, "Bandwidth", VirtualSlotTableRow::BANDWIDTH);
+        appendVirtualSlotTableRow(body, snap, "Spreading factor", VirtualSlotTableRow::SPREADING_FACTOR);
+        appendVirtualSlotTableRow(body, snap, "Coding rate", VirtualSlotTableRow::CODING_RATE);
+        appendVirtualSlotTableRow(body, snap, "TX power", VirtualSlotTableRow::TX_POWER);
+        appendVirtualSlotTableRow(body, snap, "Syncword", VirtualSlotTableRow::SYNCWORD);
+        appendVirtualSlotTableRow(body, snap, "Preamble", VirtualSlotTableRow::PREAMBLE);
+        appendVirtualSlotTableRow(body, snap, "Auto CAD", VirtualSlotTableRow::AUTO_CAD);
+        appendVirtualSlotTableRow(body, snap, "CAD settings", VirtualSlotTableRow::CAD_CUSTOM);
+        appendVirtualSlotTableRow(body, snap, "CAD symbols", VirtualSlotTableRow::CAD_SYMBOLS);
+        appendVirtualSlotTableRow(body, snap, "CAD detection peak", VirtualSlotTableRow::CAD_DET_PEAK);
+        appendVirtualSlotTableRow(body, snap, "CAD detection minimum", VirtualSlotTableRow::CAD_DET_MIN);
+        appendVirtualSlotTableRow(body, snap, "CAD exit mode", VirtualSlotTableRow::CAD_EXIT_MODE);
+        appendVirtualSlotTableRow(body, snap, "Receive mirroring", VirtualSlotTableRow::RECEIVE_MIRRORING);
+        body += F("</tbody></table></div>");
+    } else {
+        body += F("<h3>Radio</h3><div class='grid'>");
+        body += "<div class='kv'><span class='k'>State</span><span class='v'>" + String(radioStateLabel(snap)) + "</span></div>";
+        body += "<div class='kv'><span class='k'>Frequency</span><span class='v'>" + String(snap.radio.freq_hz / 1000000.0f, 3) + " MHz</span></div>";
+        body += "<div class='kv'><span class='k'>Bandwidth</span><span class='v'>" + String(snap.radio.bandwidth_hz / 1000.0f, 1) + " kHz</span></div>";
+        body += "<div class='kv'><span class='k'>Spreading factor</span><span class='v'>SF" + String(snap.radio.sf) + "</span></div>";
+        body += "<div class='kv'><span class='k'>Coding rate</span><span class='v'>4/" + String(snap.radio.cr) + "</span></div>";
+        body += "<div class='kv'><span class='k'>TX power</span><span class='v'>" + String(snap.radio.power_dbm) + " dBm</span></div>";
+        body += "<div class='kv'><span class='k'>Syncword</span><span class='v'>0x" + String(snap.radio.syncword, HEX) + "</span></div>";
+        body += "<div class='kv'><span class='k'>Preamble</span><span class='v'>" + String(snap.radio.preamble_len) + "</span></div>";
+        body += "<div class='kv'><span class='k'>Auto CAD</span><span class='v'>" + String(snap.autoCadEnabled ? "On" : "Off") + "</span></div>";
+        body += "</div>";
+    }
 
     body += F("<h3>Counters</h3><div class='grid'>");
     body += "<div class='kv'><span class='k'>RX packets</span><span class='v'>" + String(snap.status.rx_count) + "</span></div>";
     body += "<div class='kv'><span class='k'>TX packets</span><span class='v'>" + String(snap.status.tx_count) + "</span></div>";
+    body += "<div class='kv'><span class='k'>Suppressed RX</span><span class='v'>" + String(snap.suppressedRxCount) + "</span></div>";
     body += "<div class='kv'><span class='k'>CRC errors</span><span class='v'>" + String(snap.status.crc_errors) + "</span></div>";
     body += "<div class='kv'><span class='k'>Last RSSI</span><span class='v'>" + String(snap.status.last_rssi) + " dBm</span></div>";
     body += "<div class='kv'><span class='k'>Last SNR</span><span class='v'>" + String(snap.status.last_snr / 10.0f, 1) + " dB</span></div>";
@@ -1178,6 +1430,59 @@ static void handleNetworkSave() {
                    cfg.useStaticIP
                        ? F("The modem will reboot now and come back using the configured static network settings.")
                        : F("The modem will reboot now and come back using DHCP."));
+    delay(500);
+    ESP.restart();
+}
+
+static bool parseHttpUint32(const String& rawValue, uint32_t& output) {
+    String raw = rawValue;
+    raw.trim();
+    if (raw.length() == 0) return false;
+
+    char* end = nullptr;
+    unsigned long long parsed = strtoull(raw.c_str(), &end, 10);
+    if (end == raw.c_str() || *end != '\0' || parsed > 0xFFFFFFFFULL) return false;
+    output = (uint32_t)parsed;
+    return true;
+}
+
+static void handleMultiplexingSave() {
+    if (!checkAuth()) return;
+
+    uint32_t rxSlotMs = 0;
+    uint32_t activityHoldMs = 0;
+    uint32_t txEchoHoldMultiplier = 1;
+    if (!parseHttpUint32(httpServer->arg("rx_slot_ms"), rxSlotMs) ||
+        rxSlotMs < WifiManager::MIN_RX_SLOT_MS) {
+        httpServer->send(400, "text/plain",
+                         "RX slot dwell must be an integer of at least 5 milliseconds.\n");
+        return;
+    }
+    if (!parseHttpUint32(httpServer->arg("activity_hold_ms"), activityHoldMs)) {
+        httpServer->send(400, "text/plain",
+                         "Activity hold must be an unsigned integer in milliseconds.\n");
+        return;
+    }
+    if (!parseHttpUint32(httpServer->arg("tx_echo_hold_multiplier"),
+                         txEchoHoldMultiplier)) {
+        httpServer->send(400, "text/plain",
+                         "TX echo hold multiplier must be an unsigned integer.\n");
+        return;
+    }
+
+    WifiManager::Config cfg = WifiManager::getConfig();
+    cfg.rxSlotMs = rxSlotMs;
+    cfg.activityHoldMs = activityHoldMs;
+    cfg.txEchoHoldMultiplier = txEchoHoldMultiplier;
+    WifiManager::saveConfig(cfg);
+
+    Serial.printf("[OTA] multiplexing updated by %s -> rx_slot=%lu ms, activity_hold=%lu ms\n",
+                  httpServer->client().remoteIP().toString().c_str(),
+                  (unsigned long)cfg.rxSlotMs,
+                  (unsigned long)cfg.activityHoldMs);
+    sendSimplePage(F("Multiplexing saved"),
+                   F("Multiplexing saved"),
+                   F("The modem will reboot now with the updated TCP multiplexing settings."));
     delay(500);
     ESP.restart();
 }
@@ -1415,6 +1720,7 @@ void begin(const String& hn, const String& tk) {
     httpServer->on("/api/reboot", HTTP_POST, handleApiReboot);
     httpServer->on("/hostname", HTTP_POST, handleHostnameSave);
     httpServer->on("/network", HTTP_POST, handleNetworkSave);
+    httpServer->on("/multiplexing", HTTP_POST, handleMultiplexingSave);
     httpServer->on("/gps",     HTTP_POST, handleGpsSave);
     httpServer->on("/rf-lna",  HTTP_POST, handleRfLnaSave);
     httpServer->on("/token",  HTTP_POST, handleTokenSave);

--- a/firmware/src/tcp_server.cpp
+++ b/firmware/src/tcp_server.cpp
@@ -1,5 +1,5 @@
 // =============================================================
-// tcp_server.cpp — single-client TCP protocol server with optional
+// tcp_server.cpp — multi-listener TCP protocol server with optional
 // shared-token authentication.
 // =============================================================
 #include "tcp_server.h"
@@ -16,13 +16,22 @@ extern void noteTransportFrameError(uint8_t err_code);
 
 namespace TCPServer {
 
-static WiFiServer* server         = nullptr;
-static WiFiClient  client;
-static String      requiredToken  = "";
-static bool        authenticated  = false;
-static FrameParser parser;
-static uint32_t    acceptedCount  = 0;
-static uint32_t    frameCount     = 0;
+static constexpr uint8_t INVALID_SLOT = 0xFF;
+
+struct ClientSlot {
+    WiFiClient client;
+    FrameParser parser;
+    bool        occupied      = false;
+    bool        authenticated = false;
+    uint32_t    acceptedCount = 0;
+    uint32_t    frameCount    = 0;
+    uint32_t    generation    = 0;
+};
+
+static WiFiServer* listeners[MAX_TCP_CLIENTS] = {};
+static ClientSlot  slots[MAX_TCP_CLIENTS];
+static String      requiredToken = "";
+static uint8_t     commandSlot   = INVALID_SLOT;
 
 static bool requiresAuth() { return requiredToken.length() > 0; }
 
@@ -45,54 +54,66 @@ static void buildFrame(uint8_t* buf, uint16_t& outLen,
     outLen = i;
 }
 
-static void sendToClient(uint8_t cmd, const uint8_t* payload, uint16_t len) {
-    if (!client || !client.connected()) return;
+static void sendToClient(uint8_t slot, uint8_t cmd,
+                         const uint8_t* payload, uint16_t len) {
+    if (slot >= MAX_TCP_CLIENTS) return;
+    ClientSlot& state = slots[slot];
+    if (!state.occupied || !state.client.connected()) return;
     uint8_t buf[MAX_FRAME_SIZE];
     uint16_t flen = 0;
     buildFrame(buf, flen, cmd, payload, len);
-    client.write(buf, flen);
+    state.client.write(buf, flen);
 }
 
-static void sendErrorToClient(uint8_t err) {
-    sendToClient(CMD_ERROR, &err, 1);
+static void sendErrorToClient(uint8_t slot, uint8_t err) {
+    sendToClient(slot, CMD_ERROR, &err, 1);
 }
 
-static void disconnectClient() {
-    if (client) {
-        Serial.printf("[TCP] disconnect client %s auth=%u frames=%lu\n",
-                      client.remoteIP().toString().c_str(),
-                      authenticated ? 1U : 0U,
-                      (unsigned long)frameCount);
-        client.stop();
+static void disconnectClient(uint8_t slot) {
+    if (slot >= MAX_TCP_CLIENTS) return;
+    ClientSlot& state = slots[slot];
+    if (state.occupied) {
+        IPAddress addr = state.client.remoteIP();
+        Serial.printf("[TCP] disconnect slot=%u client %u.%u.%u.%u auth=%u frames=%lu\n",
+                      (unsigned)slot, addr[0], addr[1], addr[2], addr[3],
+                      state.authenticated ? 1U : 0U,
+                      (unsigned long)state.frameCount);
+        state.client.stop();
     }
-    authenticated = false;
-    frameCount = 0;
-    parser.reset();
+    state.occupied = false;
+    state.authenticated = false;
+    state.frameCount = 0;
+    state.generation++;
+    state.parser.reset();
 }
 
 static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len, TransportSource src) {
     (void)src;  // always TCP here
-    frameCount++;
-    Serial.printf("[TCP] frame cmd=0x%02X len=%u auth=%u\n",
-                  cmd, (unsigned)len, authenticated ? 1U : 0U);
+    if (commandSlot >= MAX_TCP_CLIENTS) return;
+    ClientSlot& state = slots[commandSlot];
+    state.frameCount++;
+    Serial.printf("[TCP] slot=%u frame cmd=0x%02X len=%u auth=%u\n",
+                  (unsigned)commandSlot, cmd, (unsigned)len,
+                  state.authenticated ? 1U : 0U);
 
-    if (requiresAuth() && !authenticated) {
+    if (requiresAuth() && !state.authenticated) {
         if (cmd == CMD_AUTH) {
             if (len == requiredToken.length() &&
                 memcmp(payload, requiredToken.c_str(), len) == 0) {
-                authenticated = true;
-                Serial.println("[TCP] auth OK");
-                sendToClient(CMD_AUTH_OK, nullptr, 0);
+                state.authenticated = true;
+                Serial.printf("[TCP] slot=%u auth OK\n", (unsigned)commandSlot);
+                sendToClient(commandSlot, CMD_AUTH_OK, nullptr, 0);
             } else {
-                Serial.println("[TCP] auth rejected");
-                sendErrorToClient(ERR_UNAUTHORIZED);
+                Serial.printf("[TCP] slot=%u auth rejected\n",
+                              (unsigned)commandSlot);
+                sendErrorToClient(commandSlot, ERR_UNAUTHORIZED);
                 delay(5);
-                disconnectClient();
+                disconnectClient(commandSlot);
             }
         } else {
-            sendErrorToClient(ERR_UNAUTHORIZED);
+            sendErrorToClient(commandSlot, ERR_UNAUTHORIZED);
             delay(5);
-            disconnectClient();
+            disconnectClient(commandSlot);
         }
         return;
     }
@@ -100,7 +121,7 @@ static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len, Transpo
     // Authenticated (or no auth required)
     if (cmd == CMD_AUTH) {
         // Idempotent ack — client may always send AUTH.
-        sendToClient(CMD_AUTH_OK, nullptr, 0);
+        sendToClient(commandSlot, CMD_AUTH_OK, nullptr, 0);
         return;
     }
 
@@ -109,85 +130,179 @@ static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len, Transpo
 
 static void onFrameErr(uint8_t err_code, TransportSource src) {
     (void)src;
-    Serial.printf("[TCP] frame parse error 0x%02X\n", err_code);
+    if (commandSlot >= MAX_TCP_CLIENTS) return;
+    Serial.printf("[TCP] slot=%u frame parse error 0x%02X\n",
+                  (unsigned)commandSlot, err_code);
     noteTransportFrameError(err_code);
-    sendErrorToClient(err_code);
+    sendErrorToClient(commandSlot, err_code);
 }
 
-void begin(uint16_t port, const String& token) {
+bool begin(uint16_t port, const String& token) {
     end();
     requiredToken = token;
-    authenticated = false;
-    parser.reset();
-    server = new WiFiServer(port);
-    server->begin();
-    server->setNoDelay(true);
+    commandSlot = INVALID_SLOT;
+    const uint32_t basePort = port ? port : 5055u;
+    const uint32_t lastPort = basePort + MAX_TCP_CLIENTS - 1u;
+    if (lastPort > 0xFFFFu) {
+        Serial.printf("[TCP] invalid base port %lu: slots require %lu-%lu\n",
+                      (unsigned long)basePort,
+                      (unsigned long)basePort,
+                      (unsigned long)lastPort);
+        return false;
+    }
+    for (uint8_t slot = 0; slot < MAX_TCP_CLIENTS; slot++) {
+        slots[slot].parser.reset();
+        listeners[slot] = new WiFiServer((uint16_t)(basePort + slot));
+        listeners[slot]->begin();
+        listeners[slot]->setNoDelay(true);
+    }
+    Serial.printf("[TCP] listening on %lu-%lu auth=%s\n",
+                  (unsigned long)basePort, (unsigned long)lastPort,
+                  requiresAuth() ? "required" : "open");
+    return true;
 }
 
 void end() {
-    disconnectClient();
-    if (server) {
-        server->end();
-        delete server;
-        server = nullptr;
+    commandSlot = INVALID_SLOT;
+    for (uint8_t slot = 0; slot < MAX_TCP_CLIENTS; slot++) {
+        disconnectClient(slot);
+        if (listeners[slot]) {
+            listeners[slot]->end();
+            delete listeners[slot];
+            listeners[slot] = nullptr;
+        }
     }
 }
 
 void loop() {
-    if (!server) return;
+    for (uint8_t slot = 0; slot < MAX_TCP_CLIENTS; slot++) {
+        if (!listeners[slot]) continue;
+        ClientSlot& state = slots[slot];
 
-    // Accept incoming connection if no current client
-    if (!client || !client.connected()) {
-        if (client) disconnectClient();
-        WiFiClient incoming = server->available();
-        if (incoming) {
-            // Hard LAN-only policy: drop public-IP clients before
-            // touching the parser. No log spam beyond the rejection
-            // notice; this is a normal firewall behaviour.
-            IPAddress addr = incoming.remoteIP();
-            if (!isLanAddress(addr)) {
-                Serial.printf(
-                    "[TCP] rejecting non-LAN client %u.%u.%u.%u "
-                    "(firmware accepts only RFC1918 / link-local / loopback)\n",
-                    addr[0], addr[1], addr[2], addr[3]);
-                incoming.stop();
-                return;
-            }
-            client = incoming;
-            client.setNoDelay(true);
-            parser.reset();
-            authenticated = false;
-            frameCount = 0;
-            acceptedCount++;
-            Serial.printf("[TCP] accepted client %s (#%lu, auth=%s)\n",
-                          client.remoteIP().toString().c_str(),
-                          (unsigned long)acceptedCount,
-                          requiresAuth() ? "required" : "open");
+        // A connected socket remains untouched while RF activity changes.
+        // Only an actual disconnected socket is reset and replaced.
+        if (state.occupied && !state.client.connected()) {
+            disconnectClient(slot);
         }
-    }
 
-    // Read available bytes through the parser
-    if (client && client.connected()) {
-        while (client.available()) {
-            uint8_t b = (uint8_t)client.read();
-            frameparser_feed(parser, b, TransportSource::TCP, onFrameOk, onFrameErr);
+        if (!state.occupied) {
+            WiFiClient incoming = listeners[slot]->available();
+            if (incoming) {
+                // Hard LAN-only policy: drop public-IP clients before
+                // touching the parser. No log spam beyond the rejection
+                // notice; this is a normal firewall behaviour.
+                IPAddress addr = incoming.remoteIP();
+                if (!isLanAddress(addr)) {
+                    Serial.printf(
+                        "[TCP] rejecting non-LAN client %u.%u.%u.%u "
+                        "(firmware accepts only RFC1918 / link-local / loopback)\n",
+                        addr[0], addr[1], addr[2], addr[3]);
+                    incoming.stop();
+                } else {
+                    state.client = incoming;
+                    state.occupied = true;
+                    state.client.setNoDelay(true);
+                    state.parser.reset();
+                    state.authenticated = false;
+                    state.frameCount = 0;
+                    state.generation++;
+                    state.acceptedCount++;
+                    Serial.printf("[TCP] accepted slot=%u client %u.%u.%u.%u (#%lu, auth=%s)\n",
+                                  (unsigned)slot, addr[0], addr[1], addr[2], addr[3],
+                                  (unsigned long)state.acceptedCount,
+                                  requiresAuth() ? "required" : "open");
+                }
+            }
+        }
+
+        // Read available bytes through this slot's parser.
+        if (state.occupied && state.client.connected()) {
+            uint8_t previousSlot = commandSlot;
+            commandSlot = slot;
+            while (state.client.available()) {
+                uint8_t b = (uint8_t)state.client.read();
+                frameparser_feed(state.parser, b, TransportSource::TCP,
+                                 onFrameOk, onFrameErr);
+            }
+            commandSlot = previousSlot;
         }
     }
 }
 
 bool isClientReady() {
-    if (!client || !client.connected()) return false;
-    return !requiresAuth() || authenticated;
+    for (uint8_t slot = 0; slot < MAX_TCP_CLIENTS; slot++) {
+        if (isSlotReady(slot)) return true;
+    }
+    return false;
 }
 
 String getClientIP() {
-    if (!client || !client.connected()) return String();
-    return client.remoteIP().toString();
+    uint8_t slot = activeSlot();
+    return slot < MAX_TCP_CLIENTS ? getSlotIP(slot) : String();
 }
 
 void write(const uint8_t* data, size_t len) {
-    if (!client || !client.connected()) return;
-    client.write(data, len);
+    if (commandSlot < MAX_TCP_CLIENTS) {
+        writeToSlot(commandSlot, data, len);
+    } else {
+        writeToReadySlots(data, len);
+    }
+}
+
+uint8_t activeSlot() {
+    if (commandSlot < MAX_TCP_CLIENTS) return commandSlot;
+    for (uint8_t slot = 0; slot < MAX_TCP_CLIENTS; slot++) {
+        if (isSlotReady(slot)) return slot;
+    }
+    for (uint8_t slot = 0; slot < MAX_TCP_CLIENTS; slot++) {
+        if (slots[slot].occupied && slots[slot].client.connected()) return slot;
+    }
+    return INVALID_SLOT;
+}
+
+bool isSlotReady(uint8_t slot) {
+    if (slot >= MAX_TCP_CLIENTS) return false;
+    ClientSlot& state = slots[slot];
+    return state.occupied && state.client.connected() &&
+           (!requiresAuth() || state.authenticated);
+}
+
+uint32_t getSlotGeneration(uint8_t slot) {
+    if (slot >= MAX_TCP_CLIENTS) return 0;
+    return slots[slot].generation;
+}
+
+String getSlotIP(uint8_t slot) {
+    if (slot >= MAX_TCP_CLIENTS || !slots[slot].occupied ||
+        !slots[slot].client.connected()) {
+        return String();
+    }
+    return slots[slot].client.remoteIP().toString();
+}
+
+void writeToSlot(uint8_t slot, const uint8_t* data, size_t len) {
+    if (slot >= MAX_TCP_CLIENTS || !data || len == 0) return;
+    ClientSlot& state = slots[slot];
+    if (!state.occupied) return;
+    if (!state.client.connected()) {
+        disconnectClient(slot);
+        return;
+    }
+    size_t written = state.client.write(data, len);
+    if (written != len && !state.client.connected()) {
+        disconnectClient(slot);
+    }
+}
+
+void writeToReadySlots(const uint8_t* data, size_t len) {
+    if (!data || len == 0) return;
+    for (uint8_t slot = 0; slot < MAX_TCP_CLIENTS; slot++) {
+        if (isSlotReady(slot)) writeToSlot(slot, data, len);
+    }
+}
+
+uint8_t currentCommandSlot() {
+    return commandSlot;
 }
 
 } // namespace TCPServer

--- a/firmware/src/w5100s_ethernet_transport.cpp
+++ b/firmware/src/w5100s_ethernet_transport.cpp
@@ -3,8 +3,8 @@
 // RAK4631 + RAK13800 / WisMesh Ethernet Gateway.
 //
 // This is deliberately protocol-compatible with the existing ESP32
-// tcp_server.cpp: one client, optional shared-token AUTH, same pyMC
-// binary frame format, same TransportSource::TCP command path.
+// tcp_server.cpp: one client per listener, optional shared-token AUTH,
+// same pyMC binary frame format, same TransportSource::TCP command path.
 // =============================================================
 
 #if defined(PYMC_ETHERNET_W5100S)
@@ -364,70 +364,97 @@ namespace EthernetManager {
 }
 
 namespace TCPServer {
-    static EthernetServer* server = nullptr;
-    static EthernetClient client;
-    static String requiredToken;
-    static bool authenticated = false;
-    static FrameParser parser;
-    static uint32_t acceptedCount = 0;
-    static uint32_t frameCount = 0;
+    static constexpr uint8_t ETHERNET_TCP_CLIENTS = 1;
+    static constexpr uint8_t INVALID_SLOT = 0xFF;
+
+    struct ClientSlot {
+        EthernetClient client;
+        FrameParser parser;
+        bool occupied = false;
+        bool authenticated = false;
+        uint32_t acceptedCount = 0;
+        uint32_t frameCount = 0;
+        uint32_t generation = 0;
+    };
+
+    static EthernetServer* listeners[ETHERNET_TCP_CLIENTS] = {};
+    static ClientSlot slots[ETHERNET_TCP_CLIENTS];
+    static String requiredToken = "";
+    static uint8_t commandSlot = INVALID_SLOT;
     static bool lastIpUsable = false;
 
     static bool requiresAuth() {
         return requiredToken.length() > 0;
     }
 
-    static void sendToClient(uint8_t cmd, const uint8_t* payload, uint16_t len) {
-        if (!client || !client.connected()) return;
+    static void sendToClient(uint8_t slot, uint8_t cmd,
+                             const uint8_t* payload, uint16_t len) {
+        if (slot >= ETHERNET_TCP_CLIENTS) return;
+        ClientSlot& state = slots[slot];
+        if (!state.occupied || !state.client.connected()) return;
         uint8_t buf[MAX_FRAME_SIZE];
         uint16_t flen = 0;
         buildFrame(buf, flen, cmd, payload, len);
-        client.write(buf, flen);
+        state.client.write(buf, flen);
     }
 
-    static void sendErrorToClient(uint8_t err) {
-        sendToClient(CMD_ERROR, &err, 1);
+    static void sendErrorToClient(uint8_t slot, uint8_t err) {
+        sendToClient(slot, CMD_ERROR, &err, 1);
     }
 
-    static void disconnectClient() {
-        if (client) {
-            Serial.printf("[TCP/ETH] disconnect auth=%u frames=%lu\n",
-                          authenticated ? 1U : 0U, (unsigned long)frameCount);
-            client.stop();
+    static void disconnectClient(uint8_t slot) {
+        if (slot >= ETHERNET_TCP_CLIENTS) return;
+        ClientSlot& state = slots[slot];
+        if (state.occupied) {
+            IPAddress addr = state.client.remoteIP();
+            Serial.printf("[TCP/ETH] disconnect slot=%u client %u.%u.%u.%u auth=%u frames=%lu\n",
+                          (unsigned)slot, addr[0], addr[1], addr[2], addr[3],
+                          state.authenticated ? 1U : 0U,
+                          (unsigned long)state.frameCount);
+            state.client.stop();
         }
-        authenticated = false;
-        frameCount = 0;
-        parser.reset();
+        state.occupied = false;
+        state.authenticated = false;
+        state.frameCount = 0;
+        state.generation++;
+        state.parser.reset();
     }
 
-    static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len, TransportSource src) {
+    static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len,
+                          TransportSource src) {
         (void)src;
-        frameCount++;
-        Serial.printf("[TCP/ETH] frame cmd=0x%02X len=%u auth=%u\n",
-                      cmd, (unsigned)len, authenticated ? 1U : 0U);
+        if (commandSlot >= ETHERNET_TCP_CLIENTS) return;
+        ClientSlot& state = slots[commandSlot];
+        state.frameCount++;
+        Serial.printf("[TCP/ETH] slot=%u frame cmd=0x%02X len=%u auth=%u\n",
+                      (unsigned)commandSlot, cmd, (unsigned)len,
+                      state.authenticated ? 1U : 0U);
 
-        if (requiresAuth() && !authenticated) {
+        if (requiresAuth() && !state.authenticated) {
             if (cmd == CMD_AUTH) {
-                if (len == requiredToken.length() && memcmp(payload, requiredToken.c_str(), len) == 0) {
-                    authenticated = true;
-                    Serial.println("[TCP/ETH] auth OK");
-                    sendToClient(CMD_AUTH_OK, nullptr, 0);
+                if (len == requiredToken.length() &&
+                    memcmp(payload, requiredToken.c_str(), len) == 0) {
+                    state.authenticated = true;
+                    Serial.printf("[TCP/ETH] slot=%u auth OK\n",
+                                  (unsigned)commandSlot);
+                    sendToClient(commandSlot, CMD_AUTH_OK, nullptr, 0);
                 } else {
-                    Serial.println("[TCP/ETH] auth rejected");
-                    sendErrorToClient(ERR_UNAUTHORIZED);
+                    Serial.printf("[TCP/ETH] slot=%u auth rejected\n",
+                                  (unsigned)commandSlot);
+                    sendErrorToClient(commandSlot, ERR_UNAUTHORIZED);
                     delay(5);
-                    disconnectClient();
+                    disconnectClient(commandSlot);
                 }
             } else {
-                sendErrorToClient(ERR_UNAUTHORIZED);
+                sendErrorToClient(commandSlot, ERR_UNAUTHORIZED);
                 delay(5);
-                disconnectClient();
+                disconnectClient(commandSlot);
             }
             return;
         }
 
         if (cmd == CMD_AUTH) {
-            sendToClient(CMD_AUTH_OK, nullptr, 0);
+            sendToClient(commandSlot, CMD_AUTH_OK, nullptr, 0);
             return;
         }
 
@@ -436,102 +463,195 @@ namespace TCPServer {
 
     static void onFrameErr(uint8_t err_code, TransportSource src) {
         (void)src;
-        Serial.printf("[TCP/ETH] frame parse error 0x%02X\n", err_code);
+        if (commandSlot >= ETHERNET_TCP_CLIENTS) return;
+        Serial.printf("[TCP/ETH] slot=%u frame parse error 0x%02X\n",
+                      (unsigned)commandSlot, err_code);
         noteTransportFrameError(err_code);
-        sendErrorToClient(err_code);
+        sendErrorToClient(commandSlot, err_code);
     }
 
-    void begin(uint16_t port, const String& token) {
+    bool begin(uint16_t port, const String& token) {
         end();
         requiredToken = token;
-        authenticated = false;
-        parser.reset();
-        server = new EthernetServer(port ? port : PYMC_ETH_TCP_PORT);
-        server->begin();
+        commandSlot = INVALID_SLOT;
+        const uint16_t basePort = port ? port : PYMC_ETH_TCP_PORT;
+        const uint32_t lastPort = (uint32_t)basePort + ETHERNET_TCP_CLIENTS - 1u;
+        if (lastPort > 0xFFFFu) {
+            Serial.printf("[TCP/ETH] invalid base port %u\n", (unsigned)basePort);
+            return false;
+        }
+        for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+            slots[slot].parser.reset();
+            listeners[slot] = new EthernetServer((uint16_t)(basePort + slot));
+            listeners[slot]->begin();
+        }
         lastIpUsable = EthernetManager::hasIP();
-        Serial.printf("[TCP/ETH] listening on %u auth=%s\n",
-                      (unsigned)(port ? port : PYMC_ETH_TCP_PORT),
+        Serial.printf("[TCP/ETH] listening on %u-%u auth=%s\n",
+                      (unsigned)basePort,
+                      (unsigned)(basePort + ETHERNET_TCP_CLIENTS - 1),
                       requiresAuth() ? "required" : "open");
+        return true;
     }
 
     void end() {
-        disconnectClient();
-        if (server) {
-            delete server;
-            server = nullptr;
+        commandSlot = INVALID_SLOT;
+        for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+            disconnectClient(slot);
+            if (listeners[slot]) {
+                delete listeners[slot];
+                listeners[slot] = nullptr;
+            }
         }
         lastIpUsable = false;
     }
 
     void loop() {
-        if (!server) return;
-
         const bool ipUsable = EthernetManager::hasIP();
         if (!ipUsable) {
-            if (client) disconnectClient();
+            for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+                if (slots[slot].occupied) disconnectClient(slot);
+            }
             lastIpUsable = false;
             return;
         }
 
         if (!lastIpUsable) {
             // A DHCP retry after cable replug calls Ethernet.begin() again.
-            // On W5100S that can invalidate/recreate sockets, so restart the
+            // On W5100S that can invalidate/recreate sockets, so restart each
             // listener when the Ethernet path transitions back to usable.
-            server->begin();
-            lastIpUsable = true;
-            Serial.println("[TCP/ETH] IP restored; listener restarted");
-        }
-
-        if (!client || !client.connected()) {
-            if (client) disconnectClient();
-            EthernetClient incoming = server->accept();
-            if (incoming) {
-                IPAddress addr = incoming.remoteIP();
-                if (!isLanAddress(addr)) {
-                    Serial.printf("[TCP/ETH] rejecting non-LAN client %u.%u.%u.%u\n",
-                                  addr[0], addr[1], addr[2], addr[3]);
-                    incoming.stop();
-                    return;
-                }
-                client = incoming;
-                parser.reset();
-                authenticated = false;
-                frameCount = 0;
-                acceptedCount++;
-                Serial.printf("[TCP/ETH] accepted client %u.%u.%u.%u (#%lu, auth=%s)\n",
-                              addr[0], addr[1], addr[2], addr[3],
-                              (unsigned long)acceptedCount,
-                              requiresAuth() ? "required" : "open");
+            for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+                if (listeners[slot]) listeners[slot]->begin();
             }
+            lastIpUsable = true;
+            Serial.println("[TCP/ETH] IP restored; listeners restarted");
         }
 
-        if (client && client.connected()) {
-            while (client.available()) {
-                uint8_t b = (uint8_t)client.read();
-                frameparser_feed(parser, b, TransportSource::TCP, onFrameOk, onFrameErr);
+        for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+            if (!listeners[slot]) continue;
+            ClientSlot& state = slots[slot];
+
+            if (state.occupied && !state.client.connected()) {
+                disconnectClient(slot);
+            }
+
+            if (!state.occupied) {
+                EthernetClient incoming = listeners[slot]->accept();
+                if (incoming) {
+                    IPAddress addr = incoming.remoteIP();
+                    if (!isLanAddress(addr)) {
+                        Serial.printf(
+                            "[TCP/ETH] rejecting non-LAN client %u.%u.%u.%u\n",
+                            addr[0], addr[1], addr[2], addr[3]);
+                        incoming.stop();
+                    } else {
+                        state.client = incoming;
+                        state.occupied = true;
+                        state.parser.reset();
+                        state.authenticated = false;
+                        state.frameCount = 0;
+                        state.acceptedCount++;
+                        Serial.printf("[TCP/ETH] accepted slot=%u client %u.%u.%u.%u (#%lu, auth=%s)\n",
+                                      (unsigned)slot, addr[0], addr[1], addr[2], addr[3],
+                                      (unsigned long)state.acceptedCount,
+                                      requiresAuth() ? "required" : "open");
+                    }
+                }
+            }
+
+            if (state.occupied && state.client.connected()) {
+                const uint8_t previousSlot = commandSlot;
+                commandSlot = slot;
+                while (state.client.available()) {
+                    uint8_t b = (uint8_t)state.client.read();
+                    frameparser_feed(state.parser, b, TransportSource::TCP,
+                                     onFrameOk, onFrameErr);
+                }
+                commandSlot = previousSlot;
             }
         }
     }
 
     bool isClientReady() {
         if (!EthernetManager::hasIP()) return false;
-        if (!client || !client.connected()) return false;
-        return !requiresAuth() || authenticated;
+        for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+            if (isSlotReady(slot)) return true;
+        }
+        return false;
     }
 
     String getClientIP() {
         if (!EthernetManager::hasIP()) return String();
-        if (!client || !client.connected()) return String();
-        IPAddress addr = client.remoteIP();
-        char buf[16];
-        snprintf(buf, sizeof(buf), "%u.%u.%u.%u", addr[0], addr[1], addr[2], addr[3]);
-        return String(buf);
+        const uint8_t slot = activeSlot();
+        return slot < ETHERNET_TCP_CLIENTS ? getSlotIP(slot) : String();
     }
 
     void write(const uint8_t* data, size_t len) {
         if (!EthernetManager::hasIP()) return;
-        if (!client || !client.connected()) return;
-        client.write(data, len);
+        if (commandSlot < ETHERNET_TCP_CLIENTS) {
+            writeToSlot(commandSlot, data, len);
+        } else {
+            writeToReadySlots(data, len);
+        }
+    }
+
+    uint8_t activeSlot() {
+        if (commandSlot < ETHERNET_TCP_CLIENTS) return commandSlot;
+        for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+            if (isSlotReady(slot)) return slot;
+        }
+        for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+            if (slots[slot].occupied && slots[slot].client.connected()) return slot;
+        }
+        return INVALID_SLOT;
+    }
+
+    bool isSlotReady(uint8_t slot) {
+        if (slot >= ETHERNET_TCP_CLIENTS) return false;
+        ClientSlot& state = slots[slot];
+        return state.occupied && state.client.connected() &&
+               (!requiresAuth() || state.authenticated);
+    }
+
+    uint32_t getSlotGeneration(uint8_t slot) {
+        if (slot >= ETHERNET_TCP_CLIENTS) return 0;
+        return slots[slot].generation;
+    }
+
+    String getSlotIP(uint8_t slot) {
+        if (slot >= ETHERNET_TCP_CLIENTS || !slots[slot].occupied ||
+            !slots[slot].client.connected()) {
+            return String();
+        }
+        IPAddress addr = slots[slot].client.remoteIP();
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%u.%u.%u.%u",
+                 addr[0], addr[1], addr[2], addr[3]);
+        return String(buf);
+    }
+
+    void writeToSlot(uint8_t slot, const uint8_t* data, size_t len) {
+        if (slot >= ETHERNET_TCP_CLIENTS || !data || len == 0) return;
+        ClientSlot& state = slots[slot];
+        if (!state.occupied) return;
+        if (!state.client.connected()) {
+            disconnectClient(slot);
+            return;
+        }
+        size_t written = state.client.write(data, len);
+        if (written != len && !state.client.connected()) {
+            disconnectClient(slot);
+        }
+    }
+
+    void writeToReadySlots(const uint8_t* data, size_t len) {
+        if (!data || len == 0) return;
+        for (uint8_t slot = 0; slot < ETHERNET_TCP_CLIENTS; slot++) {
+            if (isSlotReady(slot)) writeToSlot(slot, data, len);
+        }
+    }
+
+    uint8_t currentCommandSlot() {
+        return commandSlot;
     }
 }
 

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -68,6 +68,9 @@ static void loadConfig() {
         cfg.tcpPort = DEFAULT_TCP_PORT;
         cfg.wifiExternalAntenna = false;
         cfg.gpsEnabled = false;
+        cfg.rxSlotMs = BUILD_DEFAULT_RX_SLOT_MS;
+        cfg.activityHoldMs = BUILD_DEFAULT_ACTIVITY_HOLD_MS;
+        cfg.txEchoHoldMultiplier = 1;
         effectiveHostname = "";
         return;
     }
@@ -84,7 +87,14 @@ static void loadConfig() {
     cfg.tcpPort     = p.getUShort("port", DEFAULT_TCP_PORT);
     cfg.wifiExternalAntenna = p.getBool("ant_ext", false);
     cfg.gpsEnabled  = p.getBool("gps_en", false);
+    cfg.rxSlotMs    = p.getUInt("rx_slot", BUILD_DEFAULT_RX_SLOT_MS);
+    cfg.activityHoldMs = p.getUInt("act_hold", BUILD_DEFAULT_ACTIVITY_HOLD_MS);
+    cfg.txEchoHoldMultiplier = p.getUInt("tx_echo_mult", 1);
     p.end();
+
+    // Reject stale or malformed NVS values while preserving the build-time
+    // default as the safe fallback for old firmware/configurations.
+    if (cfg.rxSlotMs < MIN_RX_SLOT_MS) cfg.rxSlotMs = BUILD_DEFAULT_RX_SLOT_MS;
 }
 
 bool hasWifiAntennaSwitch() {
@@ -163,25 +173,31 @@ static void refreshEffectiveHostname() {
 }
 
 void saveConfig(const Config& newCfg) {
+    Config stored = newCfg;
+    if (stored.rxSlotMs < MIN_RX_SLOT_MS) stored.rxSlotMs = BUILD_DEFAULT_RX_SLOT_MS;
+
     Preferences p;
     if (!p.begin(NVS_NAMESPACE, false)) return;
-    p.putString("ssid",  newCfg.ssid);
-    p.putString("pass",  newCfg.password);
-    p.putString("host",  sanitizeHostname(newCfg.hostname));
-    p.putBool  ("static", newCfg.useStaticIP);
-    p.putUInt  ("ip",    (uint32_t)newCfg.staticIP);
-    p.putUInt  ("gw",    (uint32_t)newCfg.gateway);
-    p.putUInt  ("sn",    (uint32_t)newCfg.subnet);
-    p.putUInt  ("dns",   (uint32_t)newCfg.dns1);
-    p.putUInt  ("dns2",  (uint32_t)newCfg.dns2);
-    p.putString("token", newCfg.tcpToken);
-    p.putUShort("port",  newCfg.tcpPort);
+    p.putString("ssid",  stored.ssid);
+    p.putString("pass",  stored.password);
+    p.putString("host",  sanitizeHostname(stored.hostname));
+    p.putBool  ("static", stored.useStaticIP);
+    p.putUInt  ("ip",    (uint32_t)stored.staticIP);
+    p.putUInt  ("gw",    (uint32_t)stored.gateway);
+    p.putUInt  ("sn",    (uint32_t)stored.subnet);
+    p.putUInt  ("dns",   (uint32_t)stored.dns1);
+    p.putUInt  ("dns2",  (uint32_t)stored.dns2);
+    p.putString("token", stored.tcpToken);
+    p.putUShort("port",  stored.tcpPort);
     if (hasWifiAntennaSwitch()) {
-        p.putBool("ant_ext", newCfg.wifiExternalAntenna);
+        p.putBool("ant_ext", stored.wifiExternalAntenna);
     }
-    p.putBool("gps_en", newCfg.gpsEnabled);
+    p.putBool("gps_en", stored.gpsEnabled);
+    p.putUInt("rx_slot", stored.rxSlotMs);
+    p.putUInt("act_hold", stored.activityHoldMs);
+    p.putUInt("tx_echo_mult", stored.txEchoHoldMultiplier);
     p.end();
-    cfg = newCfg;
+    cfg = stored;
     cfg.hostname = sanitizeHostname(cfg.hostname);
     if (!hasWifiAntennaSwitch()) {
         cfg.wifiExternalAntenna = false;

--- a/pymc_driver/test_virtual_radio_multiplex.py
+++ b/pymc_driver/test_virtual_radio_multiplex.py
@@ -1,0 +1,489 @@
+"""Host-side contract tests for the virtual-radio scheduling policy.
+
+The firmware scheduler is cooperative C++ and is not directly linkable into
+the Python test runner.  This file therefore models only the externally
+observable policy: four consecutive ports, unchanged framing, one-deep
+generation-tagged queues, RX fan-out for matching radio profiles, TX
+priority/fairness, CAD hold, and timeout classification.  Keeping these tests
+independent of sockets makes them fast enough to run in CI while the live
+hardware checklist remains separate.
+"""
+
+import importlib.util
+import re
+import unittest
+from pathlib import Path
+
+
+# Load the framing helpers without importing pymc_driver.__init__.py.  The
+# package initializer imports the optional serial transport, while these
+# contract tests intentionally need no hardware dependencies.
+_PROTOCOL_PATH = Path(__file__).with_name("protocol_constants.py")
+_PROTOCOL_SPEC = importlib.util.spec_from_file_location(
+    "virtual_radio_protocol_constants", _PROTOCOL_PATH
+)
+if _PROTOCOL_SPEC is None or _PROTOCOL_SPEC.loader is None:
+    raise ImportError(f"cannot load protocol constants from {_PROTOCOL_PATH}")
+_PROTOCOL = importlib.util.module_from_spec(_PROTOCOL_SPEC)
+_PROTOCOL_SPEC.loader.exec_module(_PROTOCOL)
+
+CMD_TX_REQUEST = _PROTOCOL.CMD_TX_REQUEST
+PROTO_SYNC = _PROTOCOL.PROTO_SYNC
+build_frame = _PROTOCOL.build_frame
+crc16_ccitt = _PROTOCOL.crc16_ccitt
+
+
+class VirtualRadioSchedulerModel:
+    """Small reference model for the firmware's externally visible policy."""
+
+    SLOT_COUNT = 4
+
+    def __init__(self, base_port=5055, rx_slot_ms=100, activity_hold_ms=2000,
+                 tx_echo_hold_multiplier=1):
+        self.base_port = 5055 if base_port == 0 else base_port
+        if self.base_port < 1 or self.base_port + self.SLOT_COUNT - 1 > 0xFFFF:
+            raise ValueError("base port cannot allocate four listeners")
+        if rx_slot_ms < 5:
+            raise ValueError("rx slot dwell must be at least 5 ms")
+        if activity_hold_ms < 0:
+            raise ValueError("activity hold must be non-negative")
+        if tx_echo_hold_multiplier < 0:
+            raise ValueError("TX echo hold multiplier must be non-negative")
+        self.rx_slot_ms = rx_slot_ms
+        self.activity_hold_ms = activity_hold_ms
+        self.tx_echo_hold_multiplier = tx_echo_hold_multiplier
+        self.generation = [0] * self.SLOT_COUNT
+        self.connected = [False] * self.SLOT_COUNT
+        self.standby = [False] * self.SLOT_COUNT
+        self.radio_settings = [None] * self.SLOT_COUNT
+        self.pending = [None] * self.SLOT_COUNT
+        self.next_tx_slot = 0
+        self.operation = "RX_SLOT"
+        self.tx_owner = None
+        self.cad_owner = None
+        self.hold_until = 0
+        self.recent_rx = {}
+        self.last_transmitted = None
+        self.suppressed_rx_count = 0
+
+    def port_for_slot(self, slot):
+        if not 0 <= slot < self.SLOT_COUNT:
+            raise IndexError(slot)
+        return self.base_port + slot
+
+    def disconnect(self, slot):
+        self.connected[slot] = False
+        self.generation[slot] += 1
+
+    def connect(self, slot):
+        self.connected[slot] = True
+        self.generation[slot] += 1
+
+    def set_radio_settings(self, slot, settings):
+        self.radio_settings[slot] = tuple(settings)
+
+    def set_standby(self, slot, standby=True):
+        self.standby[slot] = standby
+
+    @staticmethod
+    def _receive_settings(settings):
+        return (settings[0], settings[1], settings[2], settings[3], settings[5])
+
+    def receive_targets(self, active_slot):
+        """Return ready clients using the radio profile currently on air."""
+        if not self.connected[active_slot] or self.standby[active_slot]:
+            return []
+        active_settings = self.radio_settings[active_slot]
+        return [
+            slot for slot in range(self.SLOT_COUNT)
+            if self.connected[slot] and not self.standby[slot] and
+            self._receive_settings(self.radio_settings[slot]) ==
+            self._receive_settings(active_settings)
+        ]
+
+    def receive_mirrors(self, slot):
+        """Return other slots sharing only the receive-relevant settings."""
+        if not self.connected[slot] or self.standby[slot]:
+            return []
+        receive_settings = self._receive_settings(self.radio_settings[slot])
+        return [
+            other for other in range(self.SLOT_COUNT)
+            if other != slot
+            and self.connected[other]
+            and not self.standby[other]
+            and self._receive_settings(self.radio_settings[other]) == receive_settings
+        ]
+
+    def fanout_received_packet(self, active_slot, payload, now_ms):
+        """Deliver each packet/profile pair to each slot at most once per TTL."""
+        targets = self.receive_targets(active_slot)
+        if not targets:
+            return []
+
+        profile = self._receive_settings(self.radio_settings[active_slot])
+        key = (profile, bytes(payload))
+        entry = self.recent_rx.get(key)
+        if entry is None or now_ms - entry[0] >= 5000:
+            entry = (now_ms, set())
+            self.recent_rx[key] = entry
+
+        seen_at, delivered = entry
+        delivered_now = [slot for slot in targets if slot not in delivered]
+        delivered.update(delivered_now)
+        self.recent_rx[key] = (now_ms, delivered)
+        return delivered_now
+
+    def next_receive_slot(self, start):
+        """Return the next connected slot, skipping unused listeners."""
+        for offset in range(self.SLOT_COUNT):
+            slot = (start + offset) % self.SLOT_COUNT
+            if self.connected[slot]:
+                return slot
+        return None
+
+    def enqueue(self, slot, payload):
+        if not self.connected[slot]:
+            return False
+        active_owner = (
+            self.operation == "TX" and self.tx_owner == slot
+        ) or (
+            self.operation == "CAD_FOR_TX" and self.cad_owner == slot
+        )
+        if active_owner:
+            return False
+        queued = self.pending[slot]
+        if queued is not None and queued[0] != self.generation[slot]:
+            self.pending[slot] = None
+        if self.pending[slot] is not None:
+            return False
+        self.pending[slot] = (self.generation[slot], payload)
+        return True
+
+    def next_pending(self, now=None):
+        if now is not None and not self.rotation_allowed(now):
+            return None
+        for offset in range(self.SLOT_COUNT):
+            slot = (self.next_tx_slot + offset) % self.SLOT_COUNT
+            if not self.connected[slot]:
+                continue
+            queued = self.pending[slot]
+            if queued is None:
+                continue
+            if queued[0] != self.generation[slot]:
+                self.pending[slot] = None
+                continue
+            return slot
+        return None
+
+    def start_tx(self, slot):
+        self.operation = "TX"
+        self.tx_owner = slot
+
+    def finish_tx(self):
+        slot = self.tx_owner
+        self.pending[slot] = None
+        self.next_tx_slot = (slot + 1) % self.SLOT_COUNT
+        self.tx_owner = None
+        self.operation = "RX_SLOT"
+
+    def start_cad(self, operation, owner):
+        if self.operation != "RX_SLOT":
+            return "BUSY"
+        self.operation = operation
+        self.cad_owner = owner
+        return "STARTED"
+
+    def finish_cad(self, result):
+        self.operation = "RX_SLOT"
+        self.cad_owner = None
+        return result
+
+    def hold_activity(self, now, duration):
+        self.hold_until = now + duration
+
+    def rotation_allowed(self, now):
+        return now >= self.hold_until
+
+    def remember_transmitted(self, payload, completed_ms):
+        self.last_transmitted = (bytes(payload), completed_ms)
+
+    def accepts_received_packet(self, payload, now_ms):
+        if self.last_transmitted is None:
+            return True
+        sent_payload, completed_ms = self.last_transmitted
+        window = self.activity_hold_ms * self.tx_echo_hold_multiplier
+        suppressed = (
+            window > 0
+            and bytes(payload) == sent_payload
+            and now_ms - completed_ms < window
+        )
+        if suppressed:
+            self.suppressed_rx_count += 1
+        return not suppressed
+
+
+class VirtualRadioMultiplexContractTests(unittest.TestCase):
+    def test_default_ports_and_slot_zero_compatibility(self):
+        scheduler = VirtualRadioSchedulerModel()
+        self.assertEqual([scheduler.port_for_slot(i) for i in range(4)],
+                         [5055, 5056, 5057, 5058])
+
+    def test_custom_base_port_and_overflow_validation(self):
+        scheduler = VirtualRadioSchedulerModel(60000)
+        self.assertEqual(scheduler.port_for_slot(3), 60003)
+        with self.assertRaises(ValueError):
+            VirtualRadioSchedulerModel(65533)
+
+    def test_runtime_scheduler_defaults_and_validation(self):
+        scheduler = VirtualRadioSchedulerModel()
+        self.assertEqual(scheduler.rx_slot_ms, 100)
+        self.assertEqual(scheduler.activity_hold_ms, 2000)
+        self.assertEqual(scheduler.tx_echo_hold_multiplier, 1)
+        configured = VirtualRadioSchedulerModel(
+            5055, rx_slot_ms=5, activity_hold_ms=0,
+            tx_echo_hold_multiplier=3,
+        )
+        self.assertEqual(configured.rx_slot_ms, 5)
+        self.assertEqual(configured.activity_hold_ms, 0)
+        self.assertEqual(configured.tx_echo_hold_multiplier, 3)
+        with self.assertRaises(ValueError):
+            VirtualRadioSchedulerModel(rx_slot_ms=4)
+
+    def test_wire_frame_is_unchanged(self):
+        payload = b"radio-payload"
+        frame = build_frame(CMD_TX_REQUEST, payload)
+        self.assertEqual(frame[:4], bytes([PROTO_SYNC, CMD_TX_REQUEST,
+                                           len(payload), 0]))
+        self.assertEqual(frame[4:-2], payload)
+        self.assertEqual(frame[-2:], crc16_ccitt(frame[1:-2]).to_bytes(2, "little"))
+
+    def test_one_deep_queue_and_round_robin_fairness(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(0)
+        scheduler.connect(1)
+        self.assertTrue(scheduler.enqueue(0, b"zero-1"))
+        self.assertFalse(scheduler.enqueue(0, b"zero-2"))
+        self.assertTrue(scheduler.enqueue(1, b"one-1"))
+        self.assertEqual(scheduler.next_pending(), 0)
+        scheduler.start_tx(0)
+        scheduler.finish_tx()
+        self.assertEqual(scheduler.next_pending(), 1)
+
+    def test_tx_has_priority_over_rx_rotation(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(2)
+        self.assertTrue(scheduler.enqueue(2, b"urgent"))
+        self.assertEqual(scheduler.next_pending(), 2)
+        scheduler.start_tx(2)
+        self.assertEqual(scheduler.operation, "TX")
+        scheduler.finish_tx()
+        self.assertEqual(scheduler.operation, "RX_SLOT")
+
+    def test_pending_tx_waits_until_activity_hold_expires(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(0)
+        scheduler.connect(1)
+        scheduler.hold_activity(now=1000, duration=2000)
+        self.assertTrue(scheduler.enqueue(1, b"forward-after-rx"))
+
+        self.assertIsNone(scheduler.next_pending(now=2999))
+        self.assertEqual(scheduler.next_pending(now=3000), 1)
+
+    def test_exact_last_tx_reflection_is_not_counted_during_scaled_hold(self):
+        scheduler = VirtualRadioSchedulerModel(
+            activity_hold_ms=2000, tx_echo_hold_multiplier=2
+        )
+        scheduler.remember_transmitted(b"last-tx", completed_ms=1000)
+
+        self.assertFalse(scheduler.accepts_received_packet(b"last-tx", now_ms=4999))
+        self.assertEqual(scheduler.suppressed_rx_count, 1)
+        self.assertTrue(scheduler.accepts_received_packet(b"last-tx", now_ms=5000))
+        self.assertTrue(scheduler.accepts_received_packet(b"different", now_ms=1100))
+        self.assertEqual(scheduler.suppressed_rx_count, 1)
+
+    def test_zero_tx_echo_multiplier_disables_reflection_suppression(self):
+        scheduler = VirtualRadioSchedulerModel(tx_echo_hold_multiplier=0)
+        scheduler.remember_transmitted(b"last-tx", completed_ms=1000)
+        self.assertTrue(scheduler.accepts_received_packet(b"last-tx", now_ms=1001))
+
+    def test_cad_activity_hold_blocks_rotation_until_deadline(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.hold_activity(now=1000, duration=2000)
+        self.assertFalse(scheduler.rotation_allowed(2999))
+        self.assertTrue(scheduler.rotation_allowed(3000))
+
+    def test_cad_busy_is_distinct_from_start_failure_and_timeout(self):
+        scheduler = VirtualRadioSchedulerModel()
+        self.assertEqual(scheduler.start_cad("CAD_FOR_HOST", 0), "STARTED")
+        self.assertEqual(scheduler.start_cad("CAD_FOR_HOST", 1), "BUSY")
+        self.assertEqual(scheduler.finish_cad("TIMEOUT"), "TIMEOUT")
+        self.assertEqual(scheduler.start_cad("CAD_FOR_HOST", 1), "STARTED")
+        self.assertEqual(scheduler.finish_cad("START_FAILED"), "START_FAILED")
+
+    def test_disconnect_drops_stale_queue_and_allows_generation_reuse(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(1)
+        self.assertTrue(scheduler.enqueue(1, b"old-client"))
+        scheduler.disconnect(1)
+        self.assertIsNone(scheduler.next_pending())
+        scheduler.connect(1)
+        self.assertTrue(scheduler.enqueue(1, b"new-client"))
+        self.assertEqual(scheduler.pending[1][1], b"new-client")
+
+    def test_disconnect_during_tx_does_not_accept_reused_slot_until_done(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(2)
+        self.assertTrue(scheduler.enqueue(2, b"in-flight"))
+        scheduler.start_tx(2)
+        scheduler.disconnect(2)
+        self.assertFalse(scheduler.enqueue(2, b"replacement"))
+        scheduler.finish_tx()
+        scheduler.connect(2)
+        self.assertTrue(scheduler.enqueue(2, b"replacement"))
+
+    def test_receive_rotation_skips_unconnected_slots(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(1)
+        scheduler.connect(3)
+
+        self.assertEqual(scheduler.next_receive_slot(0), 1)
+        self.assertEqual(scheduler.next_receive_slot(2), 3)
+        self.assertEqual(scheduler.next_receive_slot(0), 1)
+
+        scheduler.disconnect(1)
+        self.assertEqual(scheduler.next_receive_slot(0), 3)
+        scheduler.disconnect(3)
+        self.assertIsNone(scheduler.next_receive_slot(0))
+
+    def test_received_packet_fans_out_to_matching_radio_profiles(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(0)
+        scheduler.connect(1)
+        scheduler.connect(2)
+        scheduler.set_radio_settings(0, (869618000, 62500, 8, 8, 22, 0x12, 16))
+        scheduler.set_radio_settings(1, (869618000, 62500, 8, 8, 22, 0x12, 16))
+        scheduler.set_radio_settings(2, (869618000, 62500, 7, 8, 22, 0x12, 16))
+
+        self.assertEqual(scheduler.receive_targets(0), [0, 1])
+
+    def test_received_packet_is_not_repeated_to_slots_after_echo(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(0)
+        scheduler.connect(1)
+        settings = (869618000, 62500, 8, 8, 22, 0x12, 16)
+        scheduler.set_radio_settings(0, settings)
+        scheduler.set_radio_settings(1, settings)
+
+        self.assertEqual(
+            scheduler.fanout_received_packet(0, b"packet", now_ms=1000),
+            [0, 1],
+        )
+        # A client echo/reception of the same payload must not fan out again.
+        self.assertEqual(
+            scheduler.fanout_received_packet(0, b"packet", now_ms=1100),
+            [],
+        )
+
+    def test_received_packet_can_be_delivered_again_after_duplicate_ttl(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(0)
+        scheduler.connect(1)
+        settings = (869618000, 62500, 8, 8, 22, 0x12, 16)
+        scheduler.set_radio_settings(0, settings)
+        scheduler.set_radio_settings(1, settings)
+
+        scheduler.fanout_received_packet(0, b"packet", now_ms=1000)
+        self.assertEqual(
+            scheduler.fanout_received_packet(0, b"packet", now_ms=6000),
+            [0, 1],
+        )
+
+    def test_receive_mirroring_ignores_tx_power_and_preamble(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(0)
+        scheduler.connect(1)
+        scheduler.set_radio_settings(0, (869618000, 62500, 8, 8, 22, 0x12, 16))
+        scheduler.set_radio_settings(1, (869618000, 62500, 8, 8, 14, 0x12, 32))
+
+        self.assertEqual(scheduler.receive_mirrors(0), [1])
+        self.assertEqual(scheduler.receive_mirrors(1), [0])
+
+    def test_receive_mirroring_excludes_self_and_standby_slots(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(0)
+        scheduler.connect(1)
+        scheduler.connect(2)
+        settings = (869618000, 62500, 8, 8, 22, 0x12, 16)
+        for slot in (0, 1, 2):
+            scheduler.set_radio_settings(slot, settings)
+        scheduler.set_standby(2)
+
+        self.assertEqual(scheduler.receive_mirrors(0), [1])
+        self.assertEqual(scheduler.receive_mirrors(1), [0])
+        self.assertEqual(scheduler.receive_mirrors(2), [])
+
+    def test_received_packet_does_not_cross_radio_profiles(self):
+        scheduler = VirtualRadioSchedulerModel()
+        scheduler.connect(0)
+        scheduler.connect(1)
+        scheduler.set_radio_settings(0, (869618000, 62500, 8, 8, 22, 0x12, 16))
+        scheduler.set_radio_settings(1, (868000000, 125000, 7, 5, 14, 0x34, 8))
+
+        self.assertEqual(scheduler.receive_targets(0), [0])
+
+    def test_stats_page_uses_one_stable_setting_order_for_every_slot(self):
+        ota_manager = Path(__file__).parents[1] / "firmware" / "src" / "ota_manager.cpp"
+        source = ota_manager.read_text()
+        table_start = source.index("if (snap.virtualSlotCount > 0)")
+        table_end = source.index("} else {", table_start)
+        rows = re.findall(
+            r'appendVirtualSlotTableRow\(body, snap, "([^"]+)"',
+            source[table_start:table_end],
+        )
+        self.assertEqual(
+            rows,
+            [
+                "Status",
+                "TCP port",
+                "Client",
+                "Frequency",
+                "Bandwidth",
+                "Spreading factor",
+                "Coding rate",
+                "TX power",
+                "Syncword",
+                "Preamble",
+                "Auto CAD",
+                "CAD settings",
+                "CAD symbols",
+                "CAD detection peak",
+                "CAD detection minimum",
+                "CAD exit mode",
+                "Receive mirroring",
+            ],
+        )
+
+    def test_stats_json_contract_names_receive_mirroring_field(self):
+        ota_manager = Path(__file__).parents[1] / "firmware" / "src" / "ota_manager.cpp"
+        source = ota_manager.read_text()
+        self.assertIn('\\"recieve_mirroing\\"', source)
+
+
+    def test_config_exposes_tx_echo_hold_multiplier(self):
+        firmware = Path(__file__).parents[1] / "firmware"
+        ota_source = (firmware / "src" / "ota_manager.cpp").read_text()
+        portal_source = (firmware / "src" / "config_portal.cpp").read_text()
+        config_header = (firmware / "include" / "wifi_manager.h").read_text()
+        self.assertIn("tx_echo_hold_multiplier", ota_source)
+        self.assertIn("tx_echo_hold_multiplier", portal_source)
+        self.assertIn("txEchoHoldMultiplier = 1", config_header)
+
+    def test_counters_expose_suppressed_rx(self):
+        ota_manager = Path(__file__).parents[1] / "firmware" / "src" / "ota_manager.cpp"
+        source = ota_manager.read_text()
+        self.assertIn('\\"suppressed_rx\\"', source)
+        self.assertIn("Suppressed RX", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This merge request adds TCP virtual-radio multiplexing and the supporting modem management surface. Dwell and Activity hold settings are dependent upon your configuration. You must set the activity hold long enough to recieve a complete packet for your protocol and RF settings.

This was built to allow multiplexing for more complicated setups such as per-region transmit power or spreading limits or to support use-cases like this POC openhop modem connector for meshtastic: https://github.com/Tilton53/firmware_meshtastic; allowing usage of one radio for multiple configurations/purposes.

- Adds four consecutive TCP radio slots while preserving the existing wire protocol and slot-0 compatibility.
- Implements fair TX scheduling, receive-slot rotation, CAD/activity holds, per-slot radio profiles, and profile-matched RX fan-out.
- Prevents mirrored client echoes from being re-delivered and exposes suppression counters plus per-slot mirroring state.
- Adds runtime configuration and JSON endpoints for system, radio, network, statistics, and reboot/configuration management.
- Extends authenticated HTTP/OTA handling and Ethernet transport support, with fallback to slot-o compatibility for W5100S/RAK operation.
- Documents the multiplexing configuration, API contract, Ethernet behavior, and deployment guidance in [`README.md`](openhop_modem/README.md), [`INSTALL.md`](openhop_modem/INSTALL.md), and [`API.md`](openhop_modem/API.md).
- Adds host-side scheduler contract coverage in [`test_virtual_radio_multiplex.py`](openhop_modem/pymc_driver/test_virtual_radio_multiplex.py).

## Validation

- Automated contract tests: 24 tests passed in [`test_virtual_radio_multiplex.py`](openhop_modem/pymc_driver/test_virtual_radio_multiplex.py).
- Manual hardware test completed with two openHop instances connected to an EtherMesh 1W.
- Verified operation with matching radio settings, including RX delivery across compatible clients.
- Verified operation with differing radio settings, ensuring incompatible receive profiles remain isolated.
- Confirmed no firmware build artifacts are included in the commit.

## Screenshots

<img width="787" height="831" alt="image" src="https://github.com/user-attachments/assets/d18d0cef-072b-41b8-adb7-327aa470731e" />

<img width="2038" height="2132" alt="image" src="https://github.com/user-attachments/assets/75a6b9d5-b8c1-4fb9-bc5e-c23f4be82ccc" />

<img width="2038" height="1254" alt="image" src="https://github.com/user-attachments/assets/d4c4e802-4e40-40c9-953b-88b3cd6839d3" />
