### PR TITLE
Bound ESP32 TCP protocol servicing to preserve HTTP/OTA fairness

### DIFF
--- a/firmware/include/bounded_protocol_service.h
+++ b/firmware/include/bounded_protocol_service.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct BoundedProtocolServiceResult {
+    size_t bytes_processed = 0;
+    uint8_t frames_processed = 0;
+};
+
+template <typename Client, typename FeedByte>
+BoundedProtocolServiceResult serviceBoundedProtocolInput(
+    Client& client,
+    size_t max_bytes,
+    uint8_t max_frames,
+    FeedByte feed_byte) {
+    BoundedProtocolServiceResult result;
+
+    // Check the local budgets before touching the client. This keeps the
+    // fairness guarantee independent of the network implementation's
+    // connected()/available() behavior once a pass has exhausted its quota.
+    while (result.bytes_processed < max_bytes &&
+           result.frames_processed < max_frames &&
+           client.connected() && client.available()) {
+        const int value = client.read();
+        if (value < 0) break;
+
+        ++result.bytes_processed;
+        if (feed_byte(static_cast<uint8_t>(value))) {
+            ++result.frames_processed;
+        }
+    }
+
+    return result;
+}

--- a/firmware/include/tcp_server.h
+++ b/firmware/include/tcp_server.h
@@ -1,7 +1,7 @@
 // =============================================================
-// tcp_server.h — TCP LoRa-modem protocol server (Wi-Fi STA)
-// Accepts one client; optional shared-token auth required before
-// non-AUTH commands are processed.
+// tcp_server.h — TCP LoRa-modem protocol server for ESP32 Wi-Fi
+// and native-Ethernet targets. Accepts one client; optional shared-token
+// authentication is required before non-AUTH commands are processed.
 // =============================================================
 #pragma once
 

--- a/firmware/src/tcp_server.cpp
+++ b/firmware/src/tcp_server.cpp
@@ -23,6 +23,13 @@ static bool        authenticated  = false;
 static FrameParser parser;
 static uint32_t    acceptedCount  = 0;
 static uint32_t    frameCount     = 0;
+static uint32_t    parsedFrameCount = 0;
+
+// Keep the single cooperative firmware loop fair. A command callback may do
+// synchronous radio work, so draining a busy TCP socket without a budget can
+// indefinitely postpone HTTP/OTA servicing later in loop().
+static constexpr size_t MAX_BYTES_PER_LOOP = 256;
+static constexpr uint8_t MAX_FRAMES_PER_LOOP = 1;
 
 static bool requiresAuth() { return requiredToken.length() > 0; }
 
@@ -72,6 +79,7 @@ static void disconnectClient() {
 
 static void onFrameOk(uint8_t cmd, const uint8_t* payload, uint16_t len, TransportSource src) {
     (void)src;  // always TCP here
+    parsedFrameCount++;
     frameCount++;
     Serial.printf("[TCP] frame cmd=0x%02X len=%u auth=%u\n",
                   cmd, (unsigned)len, authenticated ? 1U : 0U);
@@ -166,11 +174,25 @@ void loop() {
         }
     }
 
-    // Read available bytes through the parser
+    // Read available bytes through the parser, but always yield back to the
+    // main loop after a bounded amount of work. FrameParser keeps partial
+    // state, so frames larger than the byte budget continue on the next pass.
     if (client && client.connected()) {
-        while (client.available()) {
+        size_t bytesProcessed = 0;
+        uint8_t framesProcessed = 0;
+        uint32_t previousFrameCount = parsedFrameCount;
+
+        while (client.connected() && client.available() &&
+               bytesProcessed < MAX_BYTES_PER_LOOP &&
+               framesProcessed < MAX_FRAMES_PER_LOOP) {
             uint8_t b = (uint8_t)client.read();
+            bytesProcessed++;
             frameparser_feed(parser, b, TransportSource::TCP, onFrameOk, onFrameErr);
+
+            if (parsedFrameCount != previousFrameCount) {
+                framesProcessed++;
+                previousFrameCount = parsedFrameCount;
+            }
         }
     }
 }

--- a/firmware/src/tcp_server.cpp
+++ b/firmware/src/tcp_server.cpp
@@ -6,6 +6,7 @@
 #include "protocol.h"
 #include "frame_parser.h"
 #include "net_filter.h"
+#include "bounded_protocol_service.h"
 
 #include <WiFi.h>
 
@@ -178,22 +179,14 @@ void loop() {
     // main loop after a bounded amount of work. FrameParser keeps partial
     // state, so frames larger than the byte budget continue on the next pass.
     if (client && client.connected()) {
-        size_t bytesProcessed = 0;
-        uint8_t framesProcessed = 0;
-        uint32_t previousFrameCount = parsedFrameCount;
-
-        while (client.connected() && client.available() &&
-               bytesProcessed < MAX_BYTES_PER_LOOP &&
-               framesProcessed < MAX_FRAMES_PER_LOOP) {
-            uint8_t b = (uint8_t)client.read();
-            bytesProcessed++;
-            frameparser_feed(parser, b, TransportSource::TCP, onFrameOk, onFrameErr);
-
-            if (parsedFrameCount != previousFrameCount) {
-                framesProcessed++;
-                previousFrameCount = parsedFrameCount;
-            }
-        }
+        serviceBoundedProtocolInput(
+            client, MAX_BYTES_PER_LOOP, MAX_FRAMES_PER_LOOP,
+            [](uint8_t b) {
+                const uint32_t previousFrameCount = parsedFrameCount;
+                frameparser_feed(parser, b, TransportSource::TCP,
+                                 onFrameOk, onFrameErr);
+                return parsedFrameCount != previousFrameCount;
+            });
     }
 }
 

--- a/firmware/tests/tcp_service_budget_test.cpp
+++ b/firmware/tests/tcp_service_budget_test.cpp
@@ -1,0 +1,129 @@
+#include "bounded_protocol_service.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <initializer_list>
+
+struct FakeClient {
+    std::deque<uint8_t> bytes;
+    bool is_connected = true;
+    size_t connected_calls = 0;
+    size_t available_calls = 0;
+
+    FakeClient(std::initializer_list<uint8_t> initial) : bytes(initial) {}
+
+    bool connected() {
+        ++connected_calls;
+        return is_connected;
+    }
+
+    int available() {
+        ++available_calls;
+        return static_cast<int>(bytes.size());
+    }
+
+    int read() {
+        if (bytes.empty()) return -1;
+        const uint8_t value = bytes.front();
+        bytes.pop_front();
+        return value;
+    }
+};
+
+static FakeClient clientWithBytes(size_t count) {
+    FakeClient client({});
+    for (size_t i = 0; i < count; ++i) {
+        client.bytes.push_back(static_cast<uint8_t>(i));
+    }
+    return client;
+}
+
+static void testStopsAfterOneCompleteFrame() {
+    FakeClient client = clientWithBytes(18);
+    size_t parser_bytes = 0;
+
+    const auto result = serviceBoundedProtocolInput(
+        client, 256, 1,
+        [&parser_bytes](uint8_t) {
+            ++parser_bytes;
+            return parser_bytes % 6 == 0;
+        });
+
+    assert(result.bytes_processed == 6);
+    assert(result.frames_processed == 1);
+    assert(client.bytes.size() == 12);
+}
+
+static void testStopsAtByteBudgetWithoutAFrame() {
+    FakeClient client = clientWithBytes(300);
+
+    const auto result = serviceBoundedProtocolInput(
+        client, 256, 1, [](uint8_t) { return false; });
+
+    assert(result.bytes_processed == 256);
+    assert(result.frames_processed == 0);
+    assert(client.bytes.size() == 44);
+}
+
+static void testLargeFrameContinuesAcrossLoopPasses() {
+    FakeClient client = clientWithBytes(267);
+    size_t parser_bytes = 0;
+    auto feed = [&parser_bytes](uint8_t) {
+        ++parser_bytes;
+        return parser_bytes == 267;
+    };
+
+    const auto first = serviceBoundedProtocolInput(client, 256, 1, feed);
+    assert(first.bytes_processed == 256);
+    assert(first.frames_processed == 0);
+    assert(client.bytes.size() == 11);
+
+    const auto second = serviceBoundedProtocolInput(client, 256, 1, feed);
+    assert(second.bytes_processed == 11);
+    assert(second.frames_processed == 1);
+    assert(client.bytes.empty());
+}
+
+static void testDisconnectDuringCallbackStopsThePass() {
+    FakeClient client = clientWithBytes(20);
+    size_t parser_bytes = 0;
+
+    const auto result = serviceBoundedProtocolInput(
+        client, 256, 2,
+        [&client, &parser_bytes](uint8_t) {
+            ++parser_bytes;
+            if (parser_bytes == 6) {
+                client.is_connected = false;
+                return true;
+            }
+            return false;
+        });
+
+    assert(result.bytes_processed == 6);
+    assert(result.frames_processed == 1);
+    assert(client.bytes.size() == 14);
+}
+
+static void testZeroBudgetDoesNotTouchTheClient() {
+    FakeClient client = clientWithBytes(10);
+
+    const auto result = serviceBoundedProtocolInput(
+        client, 0, 1, [](uint8_t) { return false; });
+
+    assert(result.bytes_processed == 0);
+    assert(result.frames_processed == 0);
+    assert(client.connected_calls == 0);
+    assert(client.available_calls == 0);
+    assert(client.bytes.size() == 10);
+}
+
+int main() {
+    testStopsAfterOneCompleteFrame();
+    testStopsAtByteBudgetWithoutAFrame();
+    testLargeFrameContinuesAcrossLoopPasses();
+    testDisconnectDuringCallbackStopsThePass();
+    testZeroBudgetDoesNotTouchTheClient();
+    return 0;
+}

--- a/firmware/tools/test_tcp_service_budget.py
+++ b/firmware/tools/test_tcp_service_budget.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Compile and run the host-side TCP service fairness contract."""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import tempfile
+
+
+def main() -> int:
+    firmware_dir = pathlib.Path(__file__).resolve().parents[1]
+    compiler = shutil.which("g++")
+    if compiler is None:
+        raise SystemExit("g++ is required for the host-side fairness test")
+
+    with tempfile.TemporaryDirectory(prefix="openhop-tcp-budget-") as temp_dir:
+        executable = pathlib.Path(temp_dir) / "tcp_service_budget_test"
+        command = [
+            compiler,
+            "-std=c++17",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            f"-I{firmware_dir / 'include'}",
+            str(firmware_dir / "tests" / "tcp_service_budget_test.cpp"),
+            "-o",
+            str(executable),
+        ]
+        subprocess.run(command, check=True)
+        subprocess.run([str(executable)], check=True)
+
+    print("TCP service fairness contract: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- bounds generic ESP32 TCP protocol servicing to 256 bytes and one complete frame per cooperative loop pass
- preserves partial parser state so large and fragmented frames continue safely on the next pass
- returns control to HTTP/OTA, network maintenance, telemetry, display, GPS, and other loop work between queued TCP commands
- adds a reusable, host-tested bounded-input helper instead of leaving the fairness rule embedded in one network loop

## Root cause

The generic `TCPServer::loop()` ran before `OTAManager::loop()` and drained `while (client.available())` without a byte, frame, or time budget. Every complete frame synchronously invokes `processHostCommand()`. TX may occupy the loop for up to 4.5 seconds and CAD for up to 500 ms while feeding the task watchdog.

A busy or backlogged TCP controller could therefore keep the firmware inside TCP command servicing across multiple commands. The network stack could still answer ping and accept port-80 connections while `WebServer::handleClient()` and the rest of the cooperative loop received no execution time.

This change processes at most one valid command frame or 256 input bytes per pass. A single command may still impose its normal bounded latency, but a queue of commands can no longer monopolize the loop indefinitely.

## Affected targets

The shared ESP32 TCP server is used by all 15 current ESP network environments:

- Heltec V3, V4, V4.2, V4.3, and Wireless Tracker V2
- Ikoka Stick and XIAO Wio-SX1262
- Photon-1W ESP32-C6 and RAK3112 WisMesh
- ESP32-P4-Nano and EtherMesh-1W native Ethernet
- LilyGO T3-S3 and T-Beam S3 Supreme
- Station G2 and Station G3

Issue #52's XIAO report motivated the investigation, but the unbounded loop was shared and not XIAO-specific.

## Explicitly out of scope

- `heltec_t114` and `xiao_nrf52_wio` do not compile this TCP implementation.
- `rak4631_wismesh_eth` uses a separate W5100S transport that requires its own bounded receive-state work.
- USB and dedicated protocol UART still have separate input loops; this PR does not claim complete transport-wide fairness.
- TX and CAD command handlers remain synchronous. This prevents multi-command backlog starvation rather than eliminating the latency of one command.

## Host-side fairness contract

`python3 firmware/tools/test_tcp_service_budget.py` compiles and runs the reusable helper with a fake client. It verifies:

- multiple queued frames yield after exactly one complete frame
- malformed or incomplete traffic yields at the 256-byte limit
- a 267-byte boundary frame continues without loss across loop passes
- disconnecting during a callback stops the current pass
- an exhausted budget does not call into the client implementation

## Verification

- [x] Host-side TCP fairness contract: PASS
- [x] `git diff --check`
- [x] All 15 affected ESP32-family PlatformIO environments build successfully on current `main`
- [ ] Before/after reproduction on the original issue #52 XIAO without erasing its configuration
- [ ] Sustained TCP command backlog plus HTTP polling on hardware, including TX and CAD traffic
- [x] EtherMesh-1W ESP32-P4 native-Ethernet OTA and runtime smoke test
- [x] Heltec V4.2 ESP32-S3 OTA and runtime smoke test

## Hardware evidence status

The experimental XIAO build was stable on a second matching node, but that node did not reproduce the original failure before the update. That proves candidate stability only, not root-cause confirmation. The original node still needs an unchanged before/after test.

The current PR head (`0c4c8e0`) was also installed successfully by the maintainer through OTA on EtherMesh-1W and Heltec V4.2 hardware. Both completed basic runtime smoke testing. This broadens cross-platform stability evidence, but it does not replace the unchanged before/after reproduction still needed on issue #52’s original XIAO.

Addresses #52.