### PR TITLE
chore(firmware): prepare v1.1.0

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -169,8 +169,8 @@ static _WiFiStub WiFi;
 
 // ─── Version ─────────────────────────────────────────────────
 // Base version is shared by every board; the board's fw_suffix
-// distinguishes one binary from another (e.g. "v1.0.1-ikoka").
-#define FW_VERSION_BASE "v1.0.1"
+// distinguishes one binary from another (e.g. "v1.1.0-ikoka").
+#define FW_VERSION_BASE "v1.1.0"
 static String fwVersion;   // populated in setup()
 
 // ─── Task watchdog — self-heal on loop() hang ───────────────


### PR DESCRIPTION
## Summary

- bumps the shared openHop Modem firmware version from `v1.0.1` to `v1.1.0`
- updates the version example beside `FW_VERSION_BASE`
- leaves generated firmware assets to the protected-main asset workflow after this source change merges

## Release sequence

1. Merge this version-bump PR into `main`.
2. Build and merge refreshed assets for all 19 PlatformIO environments, including the new `station_g3` and `rak4631_usb` directories.
3. Validate every tracked checksum set and package all 19 per-target release ZIPs from the final `main` candidate.
4. Create and publish the `v1.1.0` GitHub Release from that exact final asset commit.

Do not tag the source-only merge commit before the generated firmware asset PR reaches `main`.

## Verification

- [x] `FW_VERSION_BASE` source contract reports `v1.1.0`
- [x] all 19 PlatformIO environments build successfully
- [x] all generated firmware checksum sets validate
- [x] generated release ZIP packaging succeeds twice with identical outputs
- [x] final branch diff contains only the source version bump

Draft release notes have been prepared separately for publication after the final asset commit is on `main`.
