### PR TITLE
fix(firmware): reception guard and channel checks before TX standby

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -273,26 +273,53 @@ static uint8_t cadExitMode = 0x00;  // RADIOLIB_SX126X_CAD_GOTO_STDBY
 // reception the RX path never got to consume — from wedging TX forever,
 // like MeshCore's _maxPayloadMillis.
 static uint32_t rxActivityAt = 0;
+static bool     rxHeaderSeen = false;
 
+// True while the chip reports a reception in progress. The live IRQ flags
+// are the source of truth (MeshCore CustomSX1262::isReceiving), and each
+// stage carries its own staleness bound so a stray flag cannot hold TX off:
+// a lone preamble must turn into a valid header within about one preamble +
+// header airtime, a valid header into a frame within a worst-case payload
+// airtime.
 static bool isReceivingPacket() {
     uint32_t irq = radio.getIrqFlags();
-    bool active = (irq & (RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED |
-                          RADIOLIB_SX126X_IRQ_HEADER_VALID)) != 0;
-    if (!active) {
-        rxActivityAt = 0;
-        return false;
-    }
+    bool header   = (irq & RADIOLIB_SX126X_IRQ_HEADER_VALID) != 0;
+    bool preamble = (irq & RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED) != 0;
     uint32_t now = millis();
-    if (rxActivityAt == 0) rxActivityAt = now;
-    // Worst-case airtime of a max-size frame at current settings, padded 50%.
-    uint32_t maxMs = (uint32_t)(radio.getTimeOnAir(MAX_LORA_PAYLOAD) / 1000) * 3 / 2 + 100;
-    if (now - rxActivityAt > maxMs) {
-        radio.clearIrqFlags(RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED |
-                            RADIOLIB_SX126X_IRQ_HEADER_VALID);
+
+    if (!header && rxHeaderSeen) {
+        // The header flag went away without us clearing it: the frame ended
+        // or was aborted, and the state must follow the chip.
         rxActivityAt = 0;
+        rxHeaderSeen = false;
         return false;
     }
-    return true;
+    if (header) {
+        if (!rxHeaderSeen) { rxHeaderSeen = true; rxActivityAt = now; }
+        // Worst-case airtime of a max-size frame at current settings, padded 50%.
+        uint32_t maxMs = (uint32_t)(radio.getTimeOnAir(MAX_LORA_PAYLOAD) / 1000) * 3 / 2 + 100;
+        if (now - rxActivityAt > maxMs) {
+            radio.clearIrqFlags(RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED |
+                                RADIOLIB_SX126X_IRQ_HEADER_VALID);
+            rxActivityAt = 0;
+            rxHeaderSeen = false;
+            return false;
+        }
+        return true;
+    }
+    if (preamble) {
+        if (rxActivityAt == 0) rxActivityAt = now;
+        uint32_t preMs = (uint32_t)(radio.getTimeOnAir(1) / 1000) * 3 / 2 + 100;
+        if (now - rxActivityAt > preMs) {
+            radio.clearIrqFlags(RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED);
+            rxActivityAt = 0;
+            return false;
+        }
+        return true;
+    }
+    rxActivityAt = 0;
+    rxHeaderSeen = false;
+    return false;
 }
 
 // ─── Transport state ─────────────────────────────────────────

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -912,6 +912,15 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
             sendError(ERR_PAYLOAD_TOO_BIG, src);
             break;
         }
+        // Reception guard, independent of auto-CAD: a frame being received
+        // is authoritative — refuse rather than trample it. The radio stays
+        // untouched (standby or startReceive() here would abort the frame);
+        // its terminal IRQ delivers it to the host, and the host retries the
+        // TX within its LBT budget on ERR_CHANNEL_BUSY.
+        if (isReceivingPacket()) {
+            sendError(ERR_CHANNEL_BUSY, src);
+            break;
+        }
         // v0.5.7: non-blocking TX with our own timeout.
         // The previous radio.transmit() was synchronous and could wait
         // indefinitely when SX1262 lost the TX_DONE IRQ (observed after CAD

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -184,6 +184,18 @@ class OpenHopSX1262 : public SX1262 {
 public:
     using SX1262::SX1262;
 
+    int16_t startReceive() override {
+        // RadioLib's default RX IRQ set omits PREAMBLE_DETECTED. The passive
+        // reception guard needs that flag latched before HEADER_VALID so a
+        // TX/CAD request cannot abort a frame during its preamble.
+        return SX1262::startReceive(
+            RADIOLIB_SX126X_RX_TIMEOUT_INF,
+            RADIOLIB_IRQ_RX_DEFAULT_FLAGS |
+                (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED),
+            RADIOLIB_IRQ_RX_DEFAULT_MASK,
+            0);
+    }
+
     int16_t applyRegisterPatch08B5() {
         uint8_t value = 0;
         int16_t state = readRegister(0x08B5, &value, 1);
@@ -972,12 +984,14 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
             constexpr uint8_t  CAD_AUTO_RETRIES   = 2;
             constexpr uint32_t CAD_TIMEOUT_MS     = 200;   // worst-case SF12 ≈ 100 ms
             bool channel_clear = false;
+            bool reception_busy = false;
             for (uint8_t attempt = 0; attempt < CAD_AUTO_RETRIES; attempt++) {
                 // Passive guard first: a latched in-progress reception
-                // is authoritative — no scan, no standby, no abort.
+                // is authoritative — return busy without a scan, standby,
+                // or RX restart that would abort/discard the frame.
                 if (isReceivingPacket()) {
-                    delay(50 + (micros() % 150));
-                    continue;
+                    reception_busy = true;
+                    break;
                 }
                 ChannelScanConfig_t cfg = {};
                 cfg.cad.symNum    = cadSymNum;
@@ -987,14 +1001,25 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
                 cfg.cad.irqFlags  = RADIOLIB_IRQ_CAD_DEFAULT_FLAGS;
                 cfg.cad.irqMask   = RADIOLIB_IRQ_CAD_DEFAULT_MASK;
                 dio1Flag = false;
-                if (radio.startChannelScan(cfg) != RADIOLIB_ERR_NONE) break;
+                if (radio.startChannelScan(cfg) != RADIOLIB_ERR_NONE) {
+                    dio1Flag = false;
+                    break;
+                }
                 uint32_t cad_t0 = millis();
-                while (!dio1Flag && (millis() - cad_t0) < CAD_TIMEOUT_MS) {
+                uint16_t irq = 0;
+                while ((millis() - cad_t0) < CAD_TIMEOUT_MS) {
+                    irq = radio.getIrqFlags();
+                    if (irq & RADIOLIB_SX126X_IRQ_CAD_DONE) break;
                     compatWdtReset();
                     delay(2);
                 }
-                uint16_t irq = radio.getIrqFlags();
-                radio.clearIrqFlags(RADIOLIB_IRQ_CAD_DEFAULT_FLAGS);
+                radio.clearIrqFlags(RADIOLIB_SX126X_IRQ_CAD_DONE |
+                                    RADIOLIB_SX126X_IRQ_CAD_DETECTED);
+                dio1Flag = false;
+                // A stale RX_DONE software flag must never count as CAD
+                // completion. Only the chip's CAD_DONE flag proves the scan
+                // finished and makes a clear/busy verdict meaningful.
+                if (!(irq & RADIOLIB_SX126X_IRQ_CAD_DONE)) break;
                 bool busy = (irq & RADIOLIB_SX126X_IRQ_CAD_DETECTED) != 0;
                 if (!busy) { channel_clear = true; break; }
                 // Random backoff 50-200 ms to prevent step-locking with
@@ -1004,6 +1029,13 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
                 // Arduino random() is unseeded — and identical — on the
                 // nRF52 targets.)
                 delay(50 + (micros() % 150));
+            }
+            // The passive guard already answered without changing radio
+            // state; leave RX and its terminal IRQ untouched for loop().
+            if (reception_busy) {
+                isTxActive = false;
+                sendError(ERR_CHANNEL_BUSY, src);
+                break;
             }
             if (!channel_clear) {
                 LOG_R_WARN("auto-CAD: channel busy after retries, abort TX");
@@ -1124,6 +1156,7 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
         }
 
         if (state != RADIOLIB_ERR_NONE) {
+            dio1Flag = false;
             sendError(ERR_CAD_FAILED, src);
             startReceive();
             break;
@@ -1132,12 +1165,15 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
         // 500 ms easily covers a legitimate CAD scan at any SF+symNum we use.
         const uint32_t CAD_TIMEOUT_MS = 500;
         uint32_t cadStart = millis();
-        while (!dio1Flag && (millis() - cadStart) < CAD_TIMEOUT_MS) {
+        uint16_t cadIrq = 0;
+        while ((millis() - cadStart) < CAD_TIMEOUT_MS) {
+            cadIrq = radio.getIrqFlags();
+            if (cadIrq & RADIOLIB_SX126X_IRQ_CAD_DONE) break;
             compatWdtReset();
             delay(1);
         }
 
-        if (!dio1Flag) {
+        if (!(cadIrq & RADIOLIB_SX126X_IRQ_CAD_DONE)) {
             // CAD_DONE never fired — treat as failure and clean up the chip
             // before the next request. Don't block the repeater's LBT
             // forever; reporting failure lets the host decide.
@@ -1145,23 +1181,17 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
             radio.standby();
             delay(5);
             applyConfig(currentConfig);
+            dio1Flag = false;
             sendError(ERR_CAD_FAILED, src);
             startReceive();
             break;
         }
 
-        int scanResult = radio.getChannelScanResult();
+        radio.clearIrqFlags(RADIOLIB_SX126X_IRQ_CAD_DONE |
+                            RADIOLIB_SX126X_IRQ_CAD_DETECTED);
         dio1Flag = false;
         uint8_t result[1];
-        if (scanResult == RADIOLIB_LORA_DETECTED) {
-            result[0] = 1;
-        } else if (scanResult == RADIOLIB_CHANNEL_FREE) {
-            result[0] = 0;
-        } else {
-            sendError(ERR_CAD_FAILED, src);
-            startReceive();
-            break;
-        }
+        result[0] = (cadIrq & RADIOLIB_SX126X_IRQ_CAD_DETECTED) ? 1 : 0;
         sendFrame(CMD_CAD_RESP, result, 1, src);
         // Back to RX right away: the scan parked the radio in standby, and
         // the host probes every ~200 ms for its whole LBT budget — without

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1049,6 +1049,15 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
     }
 
     case CMD_CAD_REQUEST: {
+        // Passive guard first: a reception in progress IS a busy verdict,
+        // and the standby below would abort the very frame this request is
+        // probing for. Answer busy without touching the radio — the frame's
+        // terminal IRQ will deliver it to the host.
+        if (isReceivingPacket()) {
+            uint8_t result[1] = {1};
+            sendFrame(CMD_CAD_RESP, result, 1, src);
+            break;
+        }
         // v0.5.8: non-blocking CAD with our own timeout.
         // The previous radio.scanChannel() was synchronous and would block
         // until CAD_DONE IRQ arrived. When SX1262 dropped that IRQ (first
@@ -1118,6 +1127,10 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
             break;
         }
         sendFrame(CMD_CAD_RESP, result, 1, src);
+        // Back to RX right away: the scan parked the radio in standby, and
+        // the host probes every ~200 ms for its whole LBT budget — without
+        // this the modem is deaf between probes, so it can neither receive
+        // the traffic it is deferring to nor arm the passive guard above.
         startReceive();
         break;
     }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -262,6 +262,39 @@ static uint8_t cadDetPeak  = 22;    // openHop Core default for SF7-SF8
 static uint8_t cadDetMin   = 10;    // AN1200.48 recommendation
 static uint8_t cadExitMode = 0x00;  // RADIOLIB_SX126X_CAD_GOTO_STDBY
 
+// ─── Reception-in-progress guard ─────────────────────────────
+// PREAMBLE_DETECTED / HEADER_VALID latch in the chip's IRQ status while a
+// frame is being received (DIO1 only fires on terminal IRQs, so the flags
+// stay readable here; readData() clears them once the frame completes).
+// Lets the TX path defer to an ongoing reception instead of aborting it —
+// CAD cannot do that: startChannelScan() drops to standby first, and its
+// 2-symbol scan is unreliable mid-payload anyway. Parity with MeshCore
+// CustomSX1262::isReceiving(). The millis bound keeps stale flags — a
+// reception the RX path never got to consume — from wedging TX forever,
+// like MeshCore's _maxPayloadMillis.
+static uint32_t rxActivityAt = 0;
+
+static bool isReceivingPacket() {
+    uint32_t irq = radio.getIrqFlags();
+    bool active = (irq & (RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED |
+                          RADIOLIB_SX126X_IRQ_HEADER_VALID)) != 0;
+    if (!active) {
+        rxActivityAt = 0;
+        return false;
+    }
+    uint32_t now = millis();
+    if (rxActivityAt == 0) rxActivityAt = now;
+    // Worst-case airtime of a max-size frame at current settings, padded 50%.
+    uint32_t maxMs = (uint32_t)(radio.getTimeOnAir(MAX_LORA_PAYLOAD) / 1000) * 3 / 2 + 100;
+    if (now - rxActivityAt > maxMs) {
+        radio.clearIrqFlags(RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED |
+                            RADIOLIB_SX126X_IRQ_HEADER_VALID);
+        rxActivityAt = 0;
+        return false;
+    }
+    return true;
+}
+
 // ─── Transport state ─────────────────────────────────────────
 static FrameParser serialParser;
 static FrameParser uartParser;        // protocol UART (Serial2 on nRF52)
@@ -885,24 +918,31 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
         // timeouts), which in turn blocked loop() long enough for the 30 s
         // task watchdog to reboot the firmware every minute.
         isTxActive = true;
-        radio.standby();
-        delay(1);
 
         // ─── Auto-CAD before TX (when enabled by controller) ──
         // Up to CAD_AUTO_RETRIES of CAD-with-backoff. If the
         // channel is busy after every retry, we bail with
         // ERR_CHANNEL_BUSY instead of trampling a neighbour.
         // Local decision (lowest latency vs P4-managed equivalent).
+        // All channel checks run BEFORE the standby that stages the
+        // TX: standby() aborts an in-progress reception, so the old
+        // order destroyed the very reception it was about to probe.
         if (autoCadEnabled) {
             // 2 retries (3 scans total) + tightened jitter caps
-            // worst-case main-loop blocking around ~450 ms (was ~1 s
-            // before). Important because the loop also drains the
-            // UART RX ring — at 921600 baud the controller can push
+            // worst-case main-loop blocking around ~750 ms.
+            // Important because the loop also drains the UART RX
+            // ring — at 921600 baud the controller can push
             // ~46 KB/s and our SERIAL_BUFFER_SIZE is 512 B.
             constexpr uint8_t  CAD_AUTO_RETRIES   = 2;
             constexpr uint32_t CAD_TIMEOUT_MS     = 200;   // worst-case SF12 ≈ 100 ms
             bool channel_clear = false;
             for (uint8_t attempt = 0; attempt < CAD_AUTO_RETRIES; attempt++) {
+                // Passive guard first: a latched in-progress reception
+                // is authoritative — no scan, no standby, no abort.
+                if (isReceivingPacket()) {
+                    delay(50 + (micros() % 150));
+                    continue;
+                }
                 ChannelScanConfig_t cfg = {};
                 cfg.cad.symNum    = cadSymNum;
                 cfg.cad.detPeak   = cadDetPeak;
@@ -921,9 +961,13 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
                 radio.clearIrqFlags(RADIOLIB_IRQ_CAD_DEFAULT_FLAGS);
                 bool busy = (irq & RADIOLIB_SX126X_IRQ_CAD_DETECTED) != 0;
                 if (!busy) { channel_clear = true; break; }
-                // Random backoff 50-200 ms to prevent step-locking
-                // with another sector that retried at the same time.
-                delay(20 + (millis() & 0x1F));
+                // Random backoff 50-200 ms to prevent step-locking with
+                // another sector that retried at the same time. (The old
+                // delay(20 + (millis() & 0x1F)) waited 20-51 ms despite
+                // its comment; micros() is the jitter source because
+                // Arduino random() is unseeded — and identical — on the
+                // nRF52 targets.)
+                delay(50 + (micros() % 150));
             }
             if (!channel_clear) {
                 LOG_R_WARN("auto-CAD: channel busy after retries, abort TX");
@@ -933,6 +977,9 @@ void processHostCommand(uint8_t cmd, const uint8_t* payload, uint16_t len,
                 break;
             }
         }
+
+        radio.standby();
+        delay(1);
 
         // If the operator enabled the V4.3 external RX LNA, it must be
         // treated as an RX-only state. Restore CTX HIGH before TX so the


### PR DESCRIPTION
## Problem

Firmware counterpart of the host-side LBT rework (openhop-dev/openhop_core#116 and openhop-dev/openhop_core#117). Two defects in the `CMD_TX_REQUEST` handler:

- **`radio.standby()` ran before any channel check** — aborting an in-progress reception before even probing for one. Whatever frame the modem was receiving when a TX request arrived was destroyed unconditionally.
- **The auto-CAD path could not see a frame being received.** CAD's 2-symbol scan is tuned for preambles and unreliable mid-payload, so a TX request landing mid-frame sailed through the scans and trampled a reception the modem could simply have deferred to.

A parity audit against the reworked SPI driver then surfaced three more, all in the same subsystem:

- **`CMD_CAD_REQUEST` dropped to standby unconditionally** — and the host's LBT loop issues one of these every ~200 ms for its whole budget, so each probe destroyed the very reception it was deferring to.
- **The CAD success path never returned the radio to RX** (only the error paths did): the first probe of an LBT wait parked the modem in standby until the TX finally went out — deaf between probes for the entire wait.
- **The reception guard only ran inside the auto-CAD block**, and auto-CAD defaults to off with no host-side code to enable it — so in the deployed default configuration the guard never executed at all.

Bonus defect found on the way: the CAD retry backoff's comment claimed "50-200 ms" but the code (`delay(20 + (millis() & 0x1F))`) waited 20–51 ms.

## Change (MeshCore parity)

- **Passive reception guard** `isReceivingPacket()`: `PREAMBLE_DETECTED` / `HEADER_VALID` stay latched in the chip's IRQ status while a frame is being received (DIO1 only fires on terminal IRQs; `readData()` clears the flags once the frame completes), so the guard reads them **without touching the radio** — no scan, no standby, no abort. A millis bound derived from the worst-case airtime at current settings (`getTimeOnAir(MAX_LORA_PAYLOAD)` × 1.5) keeps stale flags from wedging TX forever, like MeshCore's `_maxPayloadMillis`.
- **Checks before standby**: the auto-CAD retry loop consults the guard before each scan and defers with a jittered wait when a reception is in progress; the staging `standby()` now runs only once the channel is deemed clear. A busy verdict still answers `ERR_CHANNEL_BUSY` — which the reworked host drivers (openhop_core#2) now retry within their LBT time budget instead of dropping the packet.
- **Honest jitter**: retry backoff becomes the 50–200 ms its comment always claimed, sourced from `micros()` (Arduino `random()` is unseeded — and identical across boots — on the nRF52 targets).
- **`CMD_CAD_REQUEST` consults the guard first and answers busy without touching the radio** — the frame completes and reaches the host via `CMD_RX_PACKET`. The success path then returns the radio to RX, so the modem stays able to receive (and to arm the guard) between the host's LBT probes. This is the modem counterpart of the SPI loop's passive-first check and of its RX restore between retries.
- **The reception guard now runs on every TX request**, ahead of the auto-CAD block: a frame being received refuses the TX with `ERR_CHANNEL_BUSY`, radio untouched. Hosts with time-budgeted LBT (openhop_core#2) retry within their budget; the per-retry guard inside the auto-CAD loop is unchanged. Enabling auto-CAD by default remains an upstream decision — but the guard no longer depends on it.
- **Two-stage staleness bound** mirroring `CustomSX1262::isReceiving()`: a lone preamble must become a valid header within about one preamble + header airtime (`getTimeOnAir(1)`, a few hundred ms); only a valid header extends the claim to the worst-case payload airtime. A single payload-scale bound anchored at the first preamble let one stray flag claim the channel for 3.5 s at SF8/62.5 kHz — and the host never forces on the modem path, so packets were dropped once its budget ran out.

Each fix is a separate commit, cherry-pickable onto the base guard for field testing.

## Test plan

- [x] `pio run -e heltec_v3` / `heltec_v43` — SUCCESS (ESP32-S3 family), re-run at each commit
- [x] `pio run -e heltec_t114` / `xiao_wio_sx1262` — SUCCESS (nRF52840 family; exercises the non-ESP32 compat paths)
- [x] On-air validation on a two-repeater setup (the collision scenario that motivated the series)
- [ ] On-air validation of the CAD-probe deferral: with sustained neighbour traffic, the host log should show `Modem reports channel busy` without the modem's RX counters stalling
