### PR TITLE
fix: declare utf-8 charset for OTA update response

### DIFF
--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -1492,7 +1492,7 @@ static void handleUpdateResult() {
     } else {
         body = String(F("FAIL — ")) + Update.errorString();
     }
-    httpServer->send(ok ? 200 : 500, "text/plain", body);
+    httpServer->send(ok ? 200 : 500, "text/plain; charset=utf-8", body);
     if (ok) {
         delay(500);
         ESP.restart();


### PR DESCRIPTION
## Problem
The OTA update response message renders with mojibake characters:

> OK â€” rebooting into new firmware. If the new image fails its sanity check within 2 minutes, the bootloader will roll back automatically.

The body contains a UTF-8 em dash (`—`, bytes `E2 80 94`), but the response is served with a bare `text/plain` content type. Browsers default to decoding unlabeled `text/plain` as Windows-1252, misinterpreting the UTF-8 bytes as `â€”`.

## Fix
Declare `; charset=utf-8` on the response (`firmware/src/ota_manager.cpp` line 1495), matching the convention already used by the other UTF-8 HTML/JSON handlers in the same file. This tells the browser to decode the em dash as UTF-8.

The other `text/plain` sends in the file are ASCII-only and are left unchanged.

Minimal, single-line change.