### PR TITLE
feat(firmware): add battery stats for LilyGo T3 S3

### DIFF
--- a/firmware/include/boards/lilygo_t3s3.h
+++ b/firmware/include/boards/lilygo_t3s3.h
@@ -44,6 +44,14 @@ inline const BoardConfig BOARD = {
     .pin_user_button        = 0,      // BOOT button on GPIO0
     .user_button_active_low = true,
 
+    // LiPo monitor from Xinyuan-LilyGO/LilyGo-LoRa-Series schematic.
+    // Uses a simple voltage divider into GPIO1 with no switching.
+    .battery = {
+        .pin = 1,
+        .enable_pin = -1,
+        .multiplier = 2.000f,
+    },
+
     .max_tx_power_dbm = 22,           // SX1262 spec ceiling
 
     .use_dio3_tcxo = true,


### PR DESCRIPTION
# Summary
This MR adds battery stats to the LilyGo T3 S3 board. I'm using this on the T3 S3 I'm using as modem for my openHop repeater. The correct voltage does show on the Stats Page served by the modem over WiFi.

# Screenshot
<img width="791" height="829" alt="image" src="https://github.com/user-attachments/assets/99012d2b-8b47-4c9d-ae19-bf32d25e8ecb" />
