### PR TITLE
fix(firmware): expose Station G3 power telemetry

### DIFF
--- a/API.md
+++ b/API.md
@@ -123,13 +123,16 @@ Example:
 
 ### `GET /api/stats`
 
-Returns the combined system, radio, counters, and network state in one response.
+Returns the combined system, radio, counters, network, and GPS state in one response.
 
 Top-level keys:
+- `battery_voltage_mv`, `battery_voltage_v` — battery voltage when the board defines battery sensing; otherwise `null`
+- `bus_voltage_v`, `current_ma`, `power_mw` — Station G3 INA219 input-power readings when the monitor is available; values are `null` when its latest sample failed
 - `system` — board, firmware, hostname, uptime, die temperature, battery voltage only when the board variant defines battery sensing (`battery_voltage_mv`, `battery_voltage_v`; otherwise `null`), and Station G3-only INA219 power readings
 - `radio`
 - `counters`
 - `network`
+- `gps`
 
 ### `GET /api/config`
 

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -12,9 +12,6 @@
 #include "tcp_server.h"
 #include "wifi_manager.h"
 #include "webui_shared.h"
-#if defined(BOARD_STATION_G3)
-#include "station_g3_power.h"
-#endif
 
 #include <ArduinoJson.h>
 #include <ArduinoOTA.h>
@@ -375,6 +372,26 @@ static void sendJsonError(int code, const String& message) {
     sendJson(code, String("{\"error\":") + jsonQuote(message) + "}");
 }
 
+#if defined(BOARD_STATION_G3)
+static void appendStationG3PowerTelemetry(
+    String& body, const RuntimeStats::Snapshot& snap) {
+    if (!snap.stationG3PowerMonitorAvailable) return;
+
+    body += F(",\"bus_voltage_v\":");
+    body += snap.stationG3PowerValid
+                ? String(snap.stationG3InputVoltageV, 3) : String("null");
+    body += F(",\"current_ma\":");
+    body += snap.stationG3PowerValid
+                ? String(snap.stationG3CurrentMa, 2) : String("null");
+    body += F(",\"power_mw\":");
+    // Keep the INA219 current direction. Casting a negative reading to an
+    // unsigned integer would turn small reverse-current/noise samples into a
+    // multi-gigawatt JSON value.
+    body += snap.stationG3PowerValid
+                ? String(snap.stationG3PowerW * 1000.0f, 1) : String("null");
+}
+#endif
+
 static String buildSystemJson(const RuntimeStats::Snapshot& snap,
                               const NetworkSnapshot& net,
                               const String& clientIP) {
@@ -614,17 +631,7 @@ static String buildStatsJson(const RuntimeStats::Snapshot& snap,
                     : String("null");
     }
 #if defined(BOARD_STATION_G3)
-    {
-        const auto& power = StationG3Power::snapshot();
-        if (power.available) {
-            body += F(",\"bus_voltage_v\":");
-            body += power.valid ? String(power.inputVoltageV, 3) : String("null");
-            body += F(",\"current_ma\":");
-            body += power.valid ? String(power.currentMa, 2) : String("null");
-            body += F(",\"power_mw\":");
-            body += power.valid ? String(static_cast<uint32_t>(power.powerW * 1000.0f)) : String("null");
-        }
-    }
+    appendStationG3PowerTelemetry(body, snap);
 #endif
     body += F(",\"system\":");
     body += buildSystemJson(snap, net, clientIP);
@@ -1276,19 +1283,6 @@ static void handleApiTemp() {
                     ? String(snap.batteryChargeRatePctPerHour, 3)
                     : String("null");
     }
-#if defined(BOARD_STATION_G3)
-    {
-        const auto& power = StationG3Power::snapshot();
-        if (power.available) {
-            body += F(",\"bus_voltage_v\":");
-            body += power.valid ? String(power.inputVoltageV, 3) : String("null");
-            body += F(",\"current_ma\":");
-            body += power.valid ? String(power.currentMa, 2) : String("null");
-            body += F(",\"power_mw\":");
-            body += power.valid ? String(static_cast<uint32_t>(power.powerW * 1000.0f)) : String("null");
-        }
-    }
-#endif
     body += F(",\"firmware\":\"");
     body += snap.firmwareVersion;
     body += F("\",\"hostname\":\"");

--- a/firmware/src/ota_manager.cpp
+++ b/firmware/src/ota_manager.cpp
@@ -12,6 +12,9 @@
 #include "tcp_server.h"
 #include "wifi_manager.h"
 #include "webui_shared.h"
+#if defined(BOARD_STATION_G3)
+#include "station_g3_power.h"
+#endif
 
 #include <ArduinoJson.h>
 #include <ArduinoOTA.h>
@@ -610,6 +613,19 @@ static String buildStatsJson(const RuntimeStats::Snapshot& snap,
                     ? String(snap.batteryChargeRatePctPerHour, 3)
                     : String("null");
     }
+#if defined(BOARD_STATION_G3)
+    {
+        const auto& power = StationG3Power::snapshot();
+        if (power.available) {
+            body += F(",\"bus_voltage_v\":");
+            body += power.valid ? String(power.inputVoltageV, 3) : String("null");
+            body += F(",\"current_ma\":");
+            body += power.valid ? String(power.currentMa, 2) : String("null");
+            body += F(",\"power_mw\":");
+            body += power.valid ? String(static_cast<uint32_t>(power.powerW * 1000.0f)) : String("null");
+        }
+    }
+#endif
     body += F(",\"system\":");
     body += buildSystemJson(snap, net, clientIP);
     body += F(",\"radio\":");
@@ -1260,6 +1276,19 @@ static void handleApiTemp() {
                     ? String(snap.batteryChargeRatePctPerHour, 3)
                     : String("null");
     }
+#if defined(BOARD_STATION_G3)
+    {
+        const auto& power = StationG3Power::snapshot();
+        if (power.available) {
+            body += F(",\"bus_voltage_v\":");
+            body += power.valid ? String(power.inputVoltageV, 3) : String("null");
+            body += F(",\"current_ma\":");
+            body += power.valid ? String(power.currentMa, 2) : String("null");
+            body += F(",\"power_mw\":");
+            body += power.valid ? String(static_cast<uint32_t>(power.powerW * 1000.0f)) : String("null");
+        }
+    }
+#endif
     body += F(",\"firmware\":\"");
     body += snap.firmwareVersion;
     body += F("\",\"hostname\":\"");

--- a/firmware/tools/test_station_g3_hardware_features.py
+++ b/firmware/tools/test_station_g3_hardware_features.py
@@ -79,6 +79,15 @@ for field in (
 ):
     assert field in ota
 
+for field in ("bus_voltage_v", "current_ma", "power_mw"):
+    assert field in ota
+assert "appendStationG3PowerTelemetry(body, snap);" in ota
+assert ota.count("appendStationG3PowerTelemetry(body, snap);") == 1
+assert '#include "station_g3_power.h"' not in ota
+assert "StationG3Power::snapshot()" not in ota
+assert "static_cast<uint32_t>(snap.stationG3PowerW" not in ota
+assert "String(snap.stationG3PowerW * 1000.0f, 1)" in ota
+
 # G3 controls and power telemetry must be capability-gated, not exposed by
 # unrelated board variants or added to the binary host protocol.
 assert "if (RFFrontEnd::hasStationG3LnaControl())" in ota


### PR DESCRIPTION
## Summary

Expose the Station G3 INA219 readings as generic top-level fields from `GET /api/stats` so the openHop Repeater modem sensor can consume them:

- `bus_voltage_v`
- `current_ma`
- `power_mw`

The existing Station G3-specific values under `system` remain unchanged. `GET /api/temp` remains the focused temperature/basic-identity endpoint.

Related repeater change: openhop-dev/openhop_repeater#422

## Implementation

- Uses the `RuntimeStats::Snapshot` already captured for the response instead of taking a second hardware snapshot.
- Emits the generic fields only when the Station G3 power monitor is available.
- Emits `null` when the latest INA219 sample is invalid.
- Preserves signed current/power readings instead of casting negative power to `uint32_t`.
- Keeps all new firmware behavior behind `BOARD_STATION_G3`.
- Documents the top-level `/api/stats` fields and extends the Station G3 source contract test.

Example:

```json
{
  "battery_voltage_mv": null,
  "battery_voltage_v": null,
  "bus_voltage_v": 12.460,
  "current_ma": 59.70,
  "power_mw": 744.0,
  "system": {
    "station_g3_power_monitor_available": true,
    "station_g3_input_voltage_v": 12.460,
    "station_g3_current_ma": 59.7,
    "station_g3_power_w": 0.744
  }
}
```

The Repeater's Cayenne LPP voltage and current fields retain useful resolution. Cayenne LPP power has 1 W resolution, so sub-watt values such as 744 mW quantize to 0 W in that wire format; the sensor JSON retains the full milliwatt value.

## Verification

- `python3 firmware/tools/test_station_g3_hardware_features.py`
- `pio run -e station_g3 -e heltec_v3`
- `git diff --check`
- Firmware auto-selection chooses all 20 environments because the shared OTA manager changed.
