### PR TITLE
chore: bump firmware version to v1.3.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -352,7 +352,7 @@ To package an existing tag locally without uploading:
 
 ```bash
 python3 firmware/tools/package_release_assets.py \
-    --tag v1.2.0 --output-dir /tmp/openhop-release
+    --tag v1.3.0 --output-dir /tmp/openhop-release
 (cd /tmp/openhop-release && sha256sum -c *-SHA256SUMS.txt)
 ```
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -272,8 +272,8 @@ static _WiFiStub WiFi;
 
 // ─── Version ─────────────────────────────────────────────────
 // Base version is shared by every board; the board's fw_suffix
-// distinguishes one binary from another (e.g. "v1.2.0-ikoka").
-#define FW_VERSION_BASE "v1.2.0"
+// distinguishes one binary from another (e.g. "v1.3.0-ikoka").
+#define FW_VERSION_BASE "v1.3.0"
 static String fwVersion;   // populated in setup()
 
 // ─── Task watchdog — self-heal on loop() hang ───────────────


### PR DESCRIPTION
## Summary

- bump the shared firmware version from `v1.2.0` to `v1.3.0`
- update the local release-packaging example to use `v1.3.0`

Generated firmware manifests are intentionally not edited by hand. After this lands on `main`, the firmware asset workflow will select all 20 environments, rebuild them with the new runtime version, and open the generated asset update PR.

## Verification

- `xiao_wio_sx1262` PlatformIO build passed
- changed-file planning selects all 20 firmware environments
- `git diff --check origin/main..HEAD` passed
